### PR TITLE
Add PoC-in-GitHub browse link to threat snapshot output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyo
 .venv/
 venv/
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,110 +1,90 @@
 # VulnAdvisor
 
-> Plain-language CVE triage and remediation guidance, built for security teams who need answers, not more data.
+Plain-language CVE triage and remediation guidance for vulnerability management teams.
 
-No API keys. No paywalls. All data from free, authoritative public sources.
-
----
-
-## The Problem
-
-Vulnerability management teams are drowning in findings.
-
-Scanners produce hundreds (sometimes thousands) of CVEs per cycle. Each one comes with a CVSS score, a wall of technical text, and a list of affected CPEs that means nothing to most of the people who need to act on it. The result is familiar to anyone who has worked in VM:
-
-- Analysts spend hours researching each finding manually
-- Non-technical stakeholders can't understand what the risk actually means
-- Teams struggle to prioritize; everything looks urgent, so nothing gets fixed fast enough
-- Patches get missed not because people don't care, but because the signal is buried in noise
-
-Enterprise tools like Tenable, Qualys, and Rapid7 solve parts of this problem, but they cost tens of thousands of dollars a year and are out of reach for smaller security teams, MSPs, and organizations just building out their VM practice.
-
-**VulnAdvisor fills that gap.**
-
----
-
-## Who This Is For
-
-- **Security analysts** who need to triage a backlog of CVEs quickly and accurately
-- **VM engineers** who want plain-language remediation steps alongside the raw data
-- **IT administrators** who are responsible for patching but don't have a security background
-- **MSPs and consultants** who manage vulnerability programs for multiple clients
-- **Small and mid-size security teams** that can't justify enterprise VM tool pricing
-- **SOC teams** who need to quickly assess the real-world risk of a newly published CVE
-
-If you've ever copied a CVE ID into Google and spent 20 minutes piecing together what it means and what to do, this tool is for you.
+No API keys required. No paywalls. All data is pulled from free, authoritative public sources.
 
 ---
 
 ## What It Does
 
-Provide a CVE ID and get back a complete triage brief in seconds:
+Paste in a CVE ID and get back:
 
-- **Triage priority** (P1–P4) with a clear time-to-fix recommendation based on real-world risk signals
-- **Plain-language explanation** of what the vulnerability is, in terms anyone can understand
-- **Exploitation status** showing whether it is actively being weaponized right now (CISA KEV)
-- **Exploit probability** giving the statistical likelihood of exploitation in the next 30 days (EPSS)
-- **Public PoC status** indicating whether working proof-of-concept exploits are publicly available
-- **Remediation steps** covering what to patch, what version to upgrade to, and any workarounds if patching isn't immediate
-
-The output is designed to be useful to two audiences at once: technical enough for an analyst to act on, plain enough for a manager to understand.
-
----
-
-## What Makes This Different
-
-Most CVE lookup tools show you the same data that's already on NVD, just formatted differently. VulnAdvisor layers multiple risk signals together to give you a **triage decision**, not just information:
-
-| Signal | Source | Why It Matters |
-|--------|--------|----------------|
-| CVSS Score | NVD / NIST | Baseline severity from the vulnerability itself |
-| Active Exploitation | CISA KEV | Is this being used against real targets right now? |
-| Exploit Probability | EPSS (FIRST.org) | Statistical likelihood of exploitation in the wild |
-| Public PoC | PoC-in-GitHub | Are working exploits freely available to attackers? |
-
-A CVE with a 7.5 CVSS score that is actively exploited, has a 60% EPSS score, and 30 public PoC repos is not a "fix within 30 days" problem. It's a "fix today" problem. VulnAdvisor makes that call automatically.
+- **Triage priority** (P1–P4) with a clear time-to-fix recommendation
+- **Plain-language explanation** of what the vulnerability is and what an attacker could do
+- **Exploitation status** — is it being actively exploited right now? (CISA KEV)
+- **Exploit probability** — statistical likelihood it will be exploited (EPSS)
+- **Public PoC status** — are there working proof-of-concept exploits on GitHub?
+- **Remediation steps** — what to patch, what version to upgrade to, and any workarounds
 
 ---
 
 ## Data Sources
 
-All sources are free and require no registration or API keys.
-
 | Source | What it provides |
 |--------|-----------------|
-| [NVD (NIST)](https://nvd.nist.gov/) | CVE details, CVSS scores, affected products, patch versions |
+| [NVD (NIST)](https://nvd.nist.gov/) | CVE details, CVSS scores, affected products |
 | [CISA KEV](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | Actively exploited vulnerabilities catalog |
 | [EPSS (FIRST.org)](https://www.first.org/epss/) | Exploit prediction probability score |
-| [PoC-in-GitHub](https://github.com/nomi-sec/PoC-in-GitHub) | Public proof-of-concept exploit repositories |
+| [PoC-in-GitHub](https://github.com/nomi-sec/PoC-in-GitHub) | Public proof-of-concept exploit repos |
+
+All free. No registration needed.
 
 ---
 
 ## Setup
 
-### Prerequisites
+### 1. Prerequisites
 
 - Python 3.9 or later
-- `pip` (included with Python)
+- `pip` (comes with Python)
 
+Check your version:
 ```bash
 python3 --version
 ```
 
-### Install
+### 2. Clone the repository
 
 ```bash
-# Clone the repo
-git clone https://github.com/jtberry/vuln-advisor.git
+git clone https://github.com/yourusername/vuln-advisor.git
 cd vuln-advisor
+```
 
-# Create and activate a virtual environment
+### 3. Create a virtual environment
+
+This keeps the project dependencies isolated from your system Python.
+
+```bash
+# Create the virtual environment
 python3 -m venv venv
-source venv/bin/activate          # Linux / macOS
-venv\Scripts\activate.bat         # Windows (Command Prompt)
-venv\Scripts\Activate.ps1         # Windows (PowerShell)
 
-# Install dependencies
+# Activate it
+# On Linux / macOS:
+source venv/bin/activate
+
+# On Windows (Command Prompt):
+venv\Scripts\activate.bat
+
+# On Windows (PowerShell):
+venv\Scripts\Activate.ps1
+```
+
+You should see `(venv)` appear at the start of your terminal prompt.
+
+### 4. Install dependencies
+
+```bash
 pip install -r requirements.txt
+```
+
+### 5. (Optional) Environment file
+
+No API keys are required for core functionality. If you want to set up future AI-enhanced features:
+
+```bash
+cp .env.example .env
+# Edit .env and add any keys
 ```
 
 ---
@@ -123,25 +103,17 @@ python main.py CVE-2021-44228
 python main.py CVE-2021-44228 CVE-2023-44487 CVE-2024-1234
 ```
 
-### Get structured JSON output
-
-Useful for piping into other tools or scripts.
+### Get structured JSON output (for scripting or integrations)
 
 ```bash
 python main.py CVE-2021-44228 --json
 ```
 
-### Save a report to file
+### Save output to a file
 
 ```bash
 python main.py CVE-2021-44228 > report.txt
 python main.py CVE-2021-44228 --json > report.json
-```
-
-### Deactivate the virtual environment when done
-
-```bash
-deactivate
 ```
 
 ---
@@ -162,62 +134,51 @@ deactivate
   ──────────────────────────────────────────────────────────────────
     CVSS Score          10.0/10 (CRITICAL)
     Actively Exploited  YES — On CISA Known Exploited List
-    Exploit Probability 94.4%  (higher than 99.9% of all CVEs)
-    Public PoC          YES — 392 public repo(s) found
-
-  WHAT IS IT?
-  ──────────────────────────────────────────────────────────────────
-    Type:  Improper Input Validation
-
-    A flaw in Apache Log4j (a popular Java logging library) that lets an
-    attacker run any command on your system by sending a specially crafted
-    message that gets logged by the application.
-
-  WHAT DO I DO?
-  ──────────────────────────────────────────────────────────────────
-    1. [PATCH     ]  Upgrade Apache Log4j to 2.17.1 or later
-    2. [WORKAROUND]  Set LOG4J_FORMAT_MSG_NO_LOOKUPS=true if patching
-                     is not immediately possible
+    Exploit Probability 97.6%  (higher than 99.9% of all CVEs)
+    Public PoC          YES — 200+ public repo(s)
+                        https://github.com/nomi-sec/PoC-in-GitHub/tree/master/2021/CVE-2021-44228
+...
 ```
 
 ---
 
 ## Triage Priority Levels
 
-| Priority | Fix Within | Triggered When |
-|----------|------------|----------------|
-| **P1** | 24 hours | Critical CVSS + actively exploited or EPSS ≥ 50% |
-| **P2** | 7 days | High CVSS + public PoC or EPSS ≥ 30% |
-| **P3** | 30 days | Medium severity |
+| Priority | Time to Fix | When |
+|----------|-------------|------|
+| **P1** | Within 24 hours | Critical CVSS + actively exploited or high EPSS |
+| **P2** | Within 7 days | High CVSS + public PoC or elevated EPSS |
+| **P3** | Within 30 days | Medium severity |
 | **P4** | Next patch cycle | Low severity |
+
+---
+
+## Deactivating the Virtual Environment
+
+When you're done, deactivate the venv:
+
+```bash
+deactivate
+```
 
 ---
 
 ## Roadmap
 
-- [ ] Bulk CVE processing from vulnerability scanner exports
-- [ ] Web UI for team use
-- [ ] Remediation tracking (open → in progress → resolved)
+- [ ] Bulk CVE processing from scanner exports
+- [ ] Web UI
 - [ ] Jira / ServiceNow ticket creation
-- [ ] Team workspaces and shared reporting
+- [ ] Remediation tracking (open → in progress → resolved)
+- [ ] Team workspaces
 
 ---
 
 ## Contributing
 
-Pull requests are welcome. If you're adding a new data source, CWE mapping, or remediation template, please open an issue first to discuss the approach.
-
-For dev setup:
-
-```bash
-pip install -r requirements-dev.txt
-pre-commit install
-```
-
-All commits run formatting (black, isort), linting (ruff), and security checks (bandit, pip-audit) automatically.
+Pull requests welcome. Please open an issue first to discuss significant changes.
 
 ---
 
 ## License
 
-MIT. Free to use, modify, and distribute. See [LICENSE](LICENSE).
+MIT — free to use, modify, and distribute. See [LICENSE](LICENSE).

--- a/core/enricher.py
+++ b/core/enricher.py
@@ -142,6 +142,7 @@ CWE_MAP: dict[str, dict[str, str]] = {
 
 # ---------------------------------------------------------------------------
 # CVSS vector plain-language maps
+# Each dict maps the single-character CVSS vector code to a human-readable string.
 # ---------------------------------------------------------------------------
 
 _AV = {
@@ -246,6 +247,12 @@ def _extract_affected_and_patches(cve: dict):
     return affected[:10], patches[:5]
 
 
+def _poc_link(cve_id: str) -> str:
+    """Build the PoC-in-GitHub browse URL for this CVE."""
+    year = cve_id.split("-")[1] if "-" in cve_id else "unknown"
+    return f"https://github.com/nomi-sec/PoC-in-GitHub/tree/master/{year}/{cve_id}"
+
+
 def _build_remediation(
     cwe_id: Optional[str], patch_versions: list[str], references: list[Reference]
 ) -> list[RemediationStep]:
@@ -332,10 +339,11 @@ def enrich(cve_raw: dict, kev_set: set[str], epss_data: dict, poc_data: dict) ->
     epss_score = epss_data.get("score")
     epss_percentile = epss_data.get("percentile")
 
+    has_poc = poc_data.get("has_poc", False)
     poc = PoCInfo(
-        has_poc=poc_data.get("has_poc", False),
+        has_poc=has_poc,
         count=poc_data.get("count", 0),
-        sources=poc_data.get("sources", []),
+        link=_poc_link(cve_id) if has_poc else None,
     )
 
     affected, patches = _extract_affected_and_patches(cve_raw)

--- a/core/formatter.py
+++ b/core/formatter.py
@@ -10,25 +10,28 @@ from .models import EnrichedCVE
 W = 68  # output width
 
 PRIORITY_COLORS = {
-    "P1": "\033[91m",  # red
-    "P2": "\033[93m",  # yellow
-    "P3": "\033[94m",  # blue
-    "P4": "\033[92m",  # green
+    "P1": "\033[91m",
+    "P2": "\033[93m",
+    "P3": "\033[94m",
+    "P4": "\033[92m",
 }
 RESET = "\033[0m"
 BOLD = "\033[1m"
+DIM = "\033[90m"
 
 
 def _bar(char="═") -> str:
+    """Return a full-width horizontal rule."""
     return char * W
 
 
 def _section(title: str) -> str:
+    """Return a bold section header with an underline rule."""
     return f"\n  {BOLD}{title}{RESET}\n  {'─' * (W - 2)}"
 
 
 def _wrap(text: str, indent: int = 4, width: int = W) -> str:
-    """Simple word-wrap at `width` chars with leading indent."""
+    """Word-wrap text to the output width with a leading indent."""
     words = text.split()
     lines = []
     line = " " * indent
@@ -46,86 +49,78 @@ def _wrap(text: str, indent: int = 4, width: int = W) -> str:
 def print_terminal(cve: EnrichedCVE) -> None:
     p_color = PRIORITY_COLORS.get(cve.triage_priority, "")
 
-    # ── Header ──────────────────────────────────────────────────────────────
+    # ── Header ───────────────────────────────────────────────────────────────
     print(f"\n{BOLD}{_bar()}{RESET}")
     kev_tag = f"  {BOLD}\033[91m*** ACTIVELY EXPLOITED ***{RESET}" if cve.is_kev else ""
     print(f"  {BOLD}{cve.id}{RESET}  │  CVSS {cve.cvss.score} {cve.cvss.severity}{kev_tag}")
     print(f"{BOLD}{_bar()}{RESET}")
 
-    # ── Triage Priority ─────────────────────────────────────────────────────
+    # ── Triage Priority ──────────────────────────────────────────────────────
     print(_section("TRIAGE PRIORITY"))
     print(f"    {p_color}{BOLD}{cve.triage_priority} — {cve.triage_label}{RESET}")
     print(f"    {cve.triage_reason}")
 
-    # ── Threat Snapshot ─────────────────────────────────────────────────────
+    # ── Threat Snapshot ──────────────────────────────────────────────────────
     print(_section("THREAT SNAPSHOT"))
     score_str = f"{cve.cvss.score}/10" if cve.cvss.score else "N/A"
-    print(f"    CVSS Score     {score_str} ({cve.cvss.severity})")
-
+    print(f"    CVSS Score          {score_str} ({cve.cvss.severity})")
     kev_val = f"\033[91m{BOLD}YES — On CISA Known Exploited List{RESET}" if cve.is_kev else "No"
     print(f"    Actively Exploited  {kev_val}")
-
     if cve.epss_score is not None:
         pct = round(cve.epss_score * 100, 1)
         tile = round(cve.epss_percentile * 100, 1) if cve.epss_percentile else 0
-        print(f"    Exploit Probability  {pct}%  (higher than {tile}% of all CVEs)")
+        print(f"    Exploit Probability {pct}%  (higher than {tile}% of all CVEs)")
+    if cve.poc.has_poc:
+        print(f"    Public PoC          \033[91m{BOLD}YES — {cve.poc.count} public repo(s){RESET}")
+        if cve.poc.link:
+            print(f"                        {DIM}{cve.poc.link}{RESET}")
+    else:
+        print("    Public PoC          None found")
 
-    poc_val = f"\033[91m{BOLD}YES — {cve.poc.count} public repo(s) found{RESET}" if cve.poc.has_poc else "None found"
-    print(f"    Public PoC     {poc_val}")
-
-    # ── What Is It ──────────────────────────────────────────────────────────
+    # ── What Is It ───────────────────────────────────────────────────────────
     print(_section("WHAT IS IT?"))
     if cve.cwe_plain:
-        print(f"    Type:  {cve.cwe_name}")
-        print()
+        print(f"    Type:  {cve.cwe_name}\n")
         print(_wrap(cve.cwe_plain))
     print()
     print(_wrap(cve.description))
 
-    # ── How Can It Be Attacked ───────────────────────────────────────────────
+    # ── Attack Surface ───────────────────────────────────────────────────────
     print(_section("HOW CAN IT BE ATTACKED?"))
-    cvss = cve.cvss
     for label, val in [
-        ("Who can attack", cvss.attack_vector),
-        ("Complexity", cvss.attack_complexity),
-        ("Login required", cvss.privileges_required),
-        ("User action needed", cvss.user_interaction),
-        ("Blast radius", cvss.scope),
+        ("Who can attack", cve.cvss.attack_vector),
+        ("Complexity", cve.cvss.attack_complexity),
+        ("Login required", cve.cvss.privileges_required),
+        ("User action needed", cve.cvss.user_interaction),
+        ("Blast radius", cve.cvss.scope),
     ]:
         if val:
             print(f"    {label:<22}  {val}")
 
-    # ── Impact ──────────────────────────────────────────────────────────────
+    # ── Impact ───────────────────────────────────────────────────────────────
     print(_section("WHAT COULD AN ATTACKER DO?"))
     for label, val in [
-        ("Data confidentiality", cvss.confidentiality),
-        ("Data integrity", cvss.integrity),
-        ("Availability / uptime", cvss.availability),
+        ("Data confidentiality", cve.cvss.confidentiality),
+        ("Data integrity", cve.cvss.integrity),
+        ("Availability / uptime", cve.cvss.availability),
     ]:
         if val and val != "NONE":
             print(f"    {label:<26} {val} impact")
 
-    # ── Affected Products ────────────────────────────────────────────────────
+    # ── Affected Products ─────────────────────────────────────────────────────
     if cve.affected_products:
         print(_section("AFFECTED PRODUCTS"))
         for product in cve.affected_products[:6]:
             print(f"    • {product}")
 
-    # ── What To Do ──────────────────────────────────────────────────────────
+    # ── Remediation ───────────────────────────────────────────────────────────
     print(_section("WHAT DO I DO?"))
     for i, step in enumerate(cve.remediation, 1):
         tag = f"[{step.action:<10}]"
         print(f"\n    {i}. {BOLD}{tag}{RESET}")
         print(_wrap(step.description, indent=8))
 
-    # ── PoC Sources ─────────────────────────────────────────────────────────
-    if cve.poc.sources:
-        print(_section("PUBLIC PROOF-OF-CONCEPT REPOS"))
-        print("    These are real exploit demos — patch before attackers use them.\n")
-        for src in cve.poc.sources:
-            print(f"    • {src}")
-
-    # ── References ──────────────────────────────────────────────────────────
+    # ── References ────────────────────────────────────────────────────────────
     patch_refs = [r for r in cve.references if any(t in ("Patch", "Vendor Advisory", "Mitigation") for t in r.tags)]
     if patch_refs:
         print(_section("PATCH / ADVISORY REFERENCES"))
@@ -140,6 +135,4 @@ def print_terminal(cve: EnrichedCVE) -> None:
 
 
 def to_json(cve: EnrichedCVE) -> str:
-    """Return a JSON-serializable dict — ready for future API use."""
-    d = asdict(cve)
-    return json.dumps(d, indent=2)
+    return json.dumps(asdict(cve), indent=2)

--- a/core/models.py
+++ b/core/models.py
@@ -21,7 +21,7 @@ class CVSSDetails:
 class PoCInfo:
     has_poc: bool = False
     count: int = 0
-    sources: list[str] = field(default_factory=list)
+    link: Optional[str] = None  # browse URL to PoC-in-GitHub for this CVE
 
 
 @dataclass

--- a/main.py
+++ b/main.py
@@ -10,9 +10,9 @@ Usage:
 """
 
 import argparse
-import sys
-from core.fetcher import fetch_nvd, fetch_kev, fetch_epss, fetch_poc
+
 from core.enricher import enrich
+from core.fetcher import fetch_epss, fetch_kev, fetch_nvd, fetch_poc
 from core.formatter import print_terminal, to_json
 
 
@@ -30,7 +30,7 @@ def process(cve_id: str, kev_set, output_json: bool) -> bool:
         return False
 
     epss_data = fetch_epss(cve_id)
-    poc_data  = fetch_poc(cve_id)
+    poc_data = fetch_poc(cve_id)
     print("done.")
 
     enriched = enrich(cve_raw, kev_set, epss_data, poc_data)
@@ -53,7 +53,7 @@ Examples:
   python main.py CVE-2021-44228
   python main.py CVE-2021-44228 CVE-2023-44487 CVE-2024-1234
   python main.py CVE-2021-44228 --json
-        """
+        """,
     )
     parser.add_argument(
         "cves",


### PR DESCRIPTION
Replaces the raw source list with a single clickable link to the PoC-in-GitHub page for the CVE. Removes ChangeImpact model, category detection, and platform-specific remediation commands. Adds .claude/ to .gitignore