### PR TITLE
feat: add CWE-based compensating controls and Sigma detection links

### DIFF
--- a/core/formatter.py
+++ b/core/formatter.py
@@ -118,6 +118,16 @@ def print_terminal(cve: EnrichedCVE) -> None:
         print(f"\n    {i}. {BOLD}{tag}{RESET}")
         print(_wrap(step.description, indent=8))
 
+    # ── Compensating Controls ────────────────────────────────────────────────
+    if cve.compensating_controls:
+        print(_section("IF PATCHING IS NOT IMMEDIATE"))
+        print("    Reduce risk with these controls while you work toward a fix.\n")
+        for control in cve.compensating_controls:
+            print(_wrap(f"• {control}", indent=4))
+        if cve.sigma_link:
+            DIM = "\033[2m"
+            print(f"\n    {DIM}Detection rules (Sigma): {cve.sigma_link}{RESET}")
+
     # ── PoC Sources ─────────────────────────────────────────────────────────
     if cve.poc.sources:
         print(_section("PUBLIC PROOF-OF-CONCEPT REPOS"))

--- a/core/models.py
+++ b/core/models.py
@@ -55,4 +55,6 @@ class EnrichedCVE:
     affected_products: list[str]
     patch_versions: list[str]
     remediation: list[RemediationStep]
+    compensating_controls: list[str]  # general controls if patching is not immediate
+    sigma_link: Optional[str]  # Sigma rule search URL for detection rules
     references: list[Reference]


### PR DESCRIPTION
Adds an "IF PATCHING IS NOT IMMEDIATE" section to CVE output with 2-3 actionable CWE-specific controls (WAF rules, logging, network restrictions, etc.) for all 25 mapped CWEs, plus a SigmaHQ search link so analysts can find detection rules while patching is pending.

Changes:
- models.py: add compensating_controls and sigma_link to EnrichedCVE
- enricher.py: add controls lists to all 25 CWE_MAP entries, _build_compensating_controls(), _build_sigma_link()
- formatter.py: render new section in terminal output