### PR TITLE
feat: bulk CVE input from file with prioritized summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Provide a CVE ID and get back a complete triage brief in seconds:
 - **Exploit probability** giving the statistical likelihood of exploitation in the next 30 days (EPSS)
 - **Public PoC status** indicating whether working proof-of-concept exploits are publicly available
 - **Remediation steps** covering what to patch, what version to upgrade to, and any workarounds if patching isn't immediate
+- **Compensating controls** with CWE-specific actions to reduce risk while a patch is pending (WAF rules, monitoring, network restrictions, and more)
+- **Detection rule links** pointing directly to SigmaHQ community detection rules for the CVE so your SOC can monitor while patching is in progress
+- **Bulk triage** accepting a list of CVE IDs or a file from a scanner export, returning a prioritized summary table sorted P1 → P4 so the most urgent items are always at the top
 
 The output is designed to be useful to two audiences at once: technical enough for an analyst to act on, plain enough for a manager to understand.
 
@@ -119,8 +122,31 @@ python main.py CVE-2021-44228
 
 ### Look up multiple CVEs at once
 
+When more than one CVE is provided, VulnAdvisor returns a prioritized summary table (P1 first) instead of individual reports.
+
 ```bash
 python main.py CVE-2021-44228 CVE-2023-44487 CVE-2024-1234
+```
+
+### Bulk triage from a file
+
+Pass a text file with one CVE ID per line. Lines starting with `#` and blank lines are ignored.
+
+```bash
+python main.py --file cves.txt
+```
+
+```
+# cves.txt — scanner export
+CVE-2021-44228
+CVE-2023-44487
+CVE-2024-21762
+```
+
+### Show full reports after the summary
+
+```bash
+python main.py --file cves.txt --full
 ```
 
 ### Get structured JSON output
@@ -195,7 +221,7 @@ deactivate
 
 ## Roadmap
 
-- [ ] Bulk CVE processing from vulnerability scanner exports
+- [x] Bulk CVE processing from vulnerability scanner exports
 - [ ] Web UI for team use
 - [ ] Remediation tracking (open → in progress → resolved)
 - [ ] Jira / ServiceNow ticket creation

--- a/main.py
+++ b/main.py
@@ -6,44 +6,53 @@ No API keys required. All data sources are free and public.
 Usage:
   python main.py CVE-2021-44228
   python main.py CVE-2021-44228 CVE-2023-44487
+  python main.py --file cves.txt
+  python main.py --file cves.txt --full
   python main.py CVE-2021-44228 --json
 """
 
 import argparse
-import sys
-from core.fetcher import fetch_nvd, fetch_kev, fetch_epss, fetch_poc
+from pathlib import Path
+from typing import Optional
+
 from core.enricher import enrich
-from core.formatter import print_terminal, to_json
+from core.fetcher import fetch_epss, fetch_kev, fetch_nvd, fetch_poc
+from core.formatter import print_summary, print_terminal, to_json
+from core.models import EnrichedCVE
 
 
-def process(cve_id: str, kev_set, output_json: bool) -> bool:
+def _load_file(path: str) -> list[str]:
+    """Read CVE IDs from a file — one per line, # comments and blank lines ignored."""
+    try:
+        lines = Path(path).read_text().splitlines()
+    except OSError as e:
+        print(f"  [!] Could not read file '{path}': {e}")
+        return []
+    return [line.strip() for line in lines if line.strip() and not line.strip().startswith("#")]
+
+
+def fetch_and_enrich(cve_id: str, kev_set: set[str]) -> Optional[EnrichedCVE]:
+    """Fetch and enrich a single CVE. Returns None on failure."""
     cve_id = cve_id.upper().strip()
     if not cve_id.startswith("CVE-"):
         print(f"  [!] '{cve_id}' doesn't look like a valid CVE ID. Expected format: CVE-YYYY-NNNNN")
-        return False
+        return None
 
     print(f"  Fetching {cve_id}...", end=" ", flush=True)
 
     cve_raw = fetch_nvd(cve_id)
     if not cve_raw:
-        print(f"\n  [!] No NVD record found for {cve_id}. Check the ID and try again.\n")
-        return False
+        print(f"\n  [!] No NVD record found for {cve_id}. Check the ID and try again.")
+        return None
 
     epss_data = fetch_epss(cve_id)
-    poc_data  = fetch_poc(cve_id)
+    poc_data = fetch_poc(cve_id)
     print("done.")
 
-    enriched = enrich(cve_raw, kev_set, epss_data, poc_data)
-
-    if output_json:
-        print(to_json(enriched))
-    else:
-        print_terminal(enriched)
-
-    return True
+    return enrich(cve_raw, kev_set, epss_data, poc_data)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="vuln-advisor",
         description="Plain-language CVE triage and remediation guidance.",
@@ -52,14 +61,26 @@ def main():
 Examples:
   python main.py CVE-2021-44228
   python main.py CVE-2021-44228 CVE-2023-44487 CVE-2024-1234
+  python main.py --file cves.txt
+  python main.py --file cves.txt --full
   python main.py CVE-2021-44228 --json
-        """
+        """,
     )
     parser.add_argument(
         "cves",
-        nargs="+",
+        nargs="*",
         metavar="CVE-ID",
         help="One or more CVE IDs to look up",
+    )
+    parser.add_argument(
+        "--file",
+        metavar="PATH",
+        help="Path to a text file with one CVE ID per line (# comments supported)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Print the full report for every CVE after the priority summary",
     )
     parser.add_argument(
         "--json",
@@ -68,19 +89,54 @@ Examples:
     )
     args = parser.parse_args()
 
+    # Collect and deduplicate CVE IDs from args and/or file
+    all_ids: list[str] = list(args.cves)
+    if args.file:
+        all_ids.extend(_load_file(args.file))
+    seen: set[str] = set()
+    cve_ids = [x for x in all_ids if not (x.upper() in seen or seen.add(x.upper()))]  # type: ignore[func-returns-value]
+
+    if not cve_ids:
+        parser.print_help()
+        return
+
     print("\nVulnAdvisor — CVE Triage Tool")
     print("─" * 40)
     print("Loading CISA Known Exploited Vulnerabilities feed...", end=" ", flush=True)
     kev_set = fetch_kev()
     print(f"{len(kev_set)} entries loaded.\n")
 
-    success = 0
-    for cve_id in args.cves:
-        if process(cve_id, kev_set, args.json):
-            success += 1
+    results: list[EnrichedCVE] = []
+    for cve_id in cve_ids:
+        enriched = fetch_and_enrich(cve_id, kev_set)
+        if enriched:
+            results.append(enriched)
 
-    if len(args.cves) > 1:
-        print(f"\nProcessed {success}/{len(args.cves)} CVEs successfully.")
+    if not results:
+        return
+
+    if args.json:
+        if len(results) == 1:
+            print(to_json(results[0]))
+        else:
+            import json
+
+            print(json.dumps([json.loads(to_json(r)) for r in results], indent=2))
+        return
+
+    if len(results) == 1:
+        print_terminal(results[0])
+    else:
+        print_summary(results)
+        if args.full:
+            for enriched in results:
+                print_terminal(enriched)
+        else:
+            print("\n  Run with --full to see the complete report for each CVE.\n")
+
+    if len(cve_ids) > len(results):
+        failed = len(cve_ids) - len(results)
+        print(f"  [!] {failed} CVE(s) could not be retrieved.\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds --file flag to accept a text file of CVE IDs (one per line, # comments supported) and reworks multi-CVE output to show a ranked priority summary table (P1 first) instead of sequential full reports.

- main.py: add --file, --full flags; refactor process() into fetch_and_enrich() that returns EnrichedCVE; deduplicate IDs across args and file; output JSON array for multi-CVE --json
- formatter.py: add print_summary() rendering grouped P1-P4 table with CVSS, severity, KEV/PoC flags, and CWE name per row
- README.md: document --file and --full usage, add file format example, update What It Does, check off bulk triage roadmap item