### PR TITLE
feat: add SQLite cache layer for CVE lookups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,9 @@ security: ## Run security checks (bandit + pip-audit)
 
 smoke: ## Verify all modules import cleanly
 	$(PYTHON) -c "from core.enricher import enrich; \
-	              from core.formatter import print_terminal; \
+	              from core.formatter import print_terminal, print_summary; \
 	              from core.fetcher import fetch_nvd; \
+	              from cache.store import CVECache; \
 	              print('  All imports OK')"
 
 check: lint security smoke ## Run all quality checks (lint + security + smoke)

--- a/cache/store.py
+++ b/cache/store.py
@@ -1,15 +1,74 @@
 """
 cache/store.py — SQLite-backed cache for CVE lookups.
 
-Walk phase — avoids redundant API calls by storing enriched CVE data
-locally with a configurable TTL (default 24 hours). Shared across
-the CLI and API so both benefit from cached results.
+Avoids redundant API calls by storing enriched CVE JSON locally with
+a configurable TTL (default 24 hours). Shared by the CLI and API so
+both benefit from cached results.
 
-Planned interface:
-  get(cve_id)          -> EnrichedCVE | None
-  set(cve_id, data)    -> None
-  invalidate(cve_id)   -> None
-  purge_expired()      -> int   (number of entries removed)
+Usage:
+    cache = CVECache()
+    data = cache.get("CVE-2021-44228")   # returns dict or None
+    cache.set("CVE-2021-44228", data)
+    cache.purge_expired()                # call periodically to trim old entries
 """
 
-# TODO: implement SQLite cache
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+_DEFAULT_DB = Path(__file__).parent / "vulnadvisor.db"
+_DEFAULT_TTL = 60 * 60 * 24  # 24 hours in seconds
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS cve_cache (
+    cve_id      TEXT PRIMARY KEY,
+    data        TEXT NOT NULL,
+    cached_at   REAL NOT NULL
+);
+"""
+
+
+class CVECache:
+    def __init__(self, db_path: Path = _DEFAULT_DB, ttl: int = _DEFAULT_TTL) -> None:
+        self.ttl = ttl
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute(_DDL)
+        self._conn.commit()
+
+    def get(self, cve_id: str) -> Optional[dict]:
+        """Return cached data for cve_id if it exists and hasn't expired."""
+        row = self._conn.execute(
+            "SELECT data, cached_at FROM cve_cache WHERE cve_id = ?",
+            (cve_id.upper(),),
+        ).fetchone()
+        if row is None:
+            return None
+        data, cached_at = row
+        if time.time() - cached_at > self.ttl:
+            self._delete(cve_id)
+            return None
+        return json.loads(data)
+
+    def set(self, cve_id: str, data: dict) -> None:
+        """Store data for cve_id, replacing any existing entry."""
+        self._conn.execute(
+            "INSERT OR REPLACE INTO cve_cache (cve_id, data, cached_at) VALUES (?, ?, ?)",
+            (cve_id.upper(), json.dumps(data), time.time()),
+        )
+        self._conn.commit()
+
+    def purge_expired(self) -> int:
+        """Delete all entries older than TTL. Returns number of rows removed."""
+        cutoff = time.time() - self.ttl
+        cursor = self._conn.execute("DELETE FROM cve_cache WHERE cached_at < ?", (cutoff,))
+        self._conn.commit()
+        return cursor.rowcount
+
+    def _delete(self, cve_id: str) -> None:
+        self._conn.execute("DELETE FROM cve_cache WHERE cve_id = ?", (cve_id.upper(),))
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()


### PR DESCRIPTION
Adds a 24-hour TTL cache that stores raw NVD/EPSS/PoC responses so repeated lookups skip redundant API calls. KEV status is always evaluated fresh since the full feed is loaded at startup.

- cache/store.py: CVECache class — get, set, purge_expired backed by SQLite with configurable TTL (default 24h)
- main.py: wire cache into fetch_and_enrich; add --no-cache flag to force fresh API lookups when needed
- Makefile: add cache.store to smoke test imports