### PR TITLE
feat: add REST API layer with rate limiting and CVE triage endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,179 @@ deactivate
 
 ---
 
+## REST API
+
+VulnAdvisor exposes a lightweight HTTP API built with FastAPI. Useful when you want to integrate triage results into your own tooling, dashboards, or the web UI.
+
+### Install API dependencies
+
+```bash
+pip install -r requirements-api.txt
+```
+
+### Start the server
+
+```bash
+make run-api
+# or directly:
+uvicorn api.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Interactive docs are available at `http://localhost:8000/docs` once the server is running.
+
+---
+
+### Endpoints
+
+#### Health check
+
+```
+GET /api/v1/health
+```
+
+```bash
+curl http://localhost:8000/api/v1/health
+```
+
+```json
+{"status": "ok", "version": "0.2.0"}
+```
+
+---
+
+#### Single CVE lookup
+
+```
+GET /api/v1/cve/{cve_id}?exposure=internal
+```
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cve_id` | path | required | CVE ID, e.g. `CVE-2021-44228` |
+| `exposure` | query | `internal` | Asset exposure context: `internet`, `internal`, or `isolated` |
+
+```bash
+curl "http://localhost:8000/api/v1/cve/CVE-2021-44228"
+```
+
+Returns the full enriched CVE record as JSON (same data as `--json` from the CLI).
+
+---
+
+#### Bulk lookup
+
+```
+POST /api/v1/cve/bulk?exposure=internal&full=false&priority_filter=P1
+```
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `exposure` | query | `internal` | Asset exposure context |
+| `full` | query | `false` | Include full CVE records alongside the summary |
+| `priority_filter` | query | none | Restrict results to one priority bucket: `P1`, `P2`, `P3`, or `P4` |
+
+Request body:
+
+```json
+{
+  "ids": ["CVE-2021-44228", "CVE-2023-44487", "CVE-2024-21762"]
+}
+```
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/cve/bulk" \
+  -H "Content-Type: application/json" \
+  -d '{"ids": ["CVE-2021-44228", "CVE-2023-44487"]}'
+```
+
+```json
+{
+  "meta": {
+    "requested": 2,
+    "returned": 2,
+    "failed": 0,
+    "exposure": "internal"
+  },
+  "summary": {
+    "P1": [
+      {
+        "id": "CVE-2021-44228",
+        "cvss_score": 10.0,
+        "cvss_severity": "CRITICAL",
+        "is_kev": true,
+        "has_poc": true,
+        "cwe_name": "Improper Input Validation",
+        "triage_priority": "P1",
+        "triage_label": "Fix within 24 hours"
+      }
+    ],
+    "P2": [...],
+    "P3": [],
+    "P4": []
+  }
+}
+```
+
+Max 50 CVE IDs per request. Duplicates and lowercase IDs are handled automatically.
+
+---
+
+#### Priority summary counts
+
+```
+GET /api/v1/cve/summary?ids=CVE-2021-44228,CVE-2023-44487&exposure=internal
+```
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ids` | query | required | Comma-separated CVE IDs |
+| `exposure` | query | `internal` | Asset exposure context |
+
+```bash
+curl "http://localhost:8000/api/v1/cve/summary?ids=CVE-2021-44228,CVE-2023-44487"
+```
+
+```json
+{
+  "counts": {"P1": 1, "P2": 1, "P3": 0, "P4": 0},
+  "total": 2,
+  "exposure": "internal"
+}
+```
+
+Useful for dashboard widgets that show a count per bucket without fetching full records.
+
+---
+
+### Rate limits
+
+| Endpoint | Limit |
+|----------|-------|
+| `GET /cve/{cve_id}` | 30 requests / minute |
+| `GET /cve/summary` | 30 requests / minute |
+| `POST /cve/bulk` | 5 requests / minute |
+| `GET /health` | unlimited |
+
+Exceeding a limit returns `429 Too Many Requests`.
+
+---
+
+### Error format
+
+All errors use the same envelope regardless of status code:
+
+```json
+{
+  "error": {
+    "code": "invalid_cve_id",
+    "message": "Invalid CVE ID format.",
+    "detail": "CVE-bad does not match CVE-YYYY-NNNNN."
+  }
+}
+```
+
+---
+
 ## Example Output
 
 ```

--- a/api/limiter.py
+++ b/api/limiter.py
@@ -1,0 +1,15 @@
+"""
+api/limiter.py -- Shared slowapi rate limiter instance.
+
+Import this in both api/main.py (to mount as middleware) and
+api/routes/v1/cve.py (to apply per-route limits with @limiter.limit()).
+
+Using a single shared instance ensures all routes share the same in-memory
+counter store. If this were instantiated in each module separately, each
+module would get its own isolated counter and rate limits would never trigger.
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")

--- a/api/main.py
+++ b/api/main.py
@@ -1,21 +1,225 @@
 """
-api/main.py — FastAPI entry point for the VulnAdvisor REST API.
+api/main.py -- FastAPI application entry point for VulnAdvisor.
 
-Walk phase — exposes the core engine over HTTP so the web UI and
-external tools can consume triage results without running the CLI.
+Walk phase -- exposes the core engine over HTTP so the web UI and external
+tools can consume triage results without running the CLI.
 
 Install deps:  pip install -r requirements-api.txt
 Run with:      make run-api
                uvicorn api.main:app --reload
+
+Middleware stack (outermost to innermost):
+  1. TrustedHostMiddleware -- rejects requests with unexpected Host headers
+  2. CORSMiddleware        -- adds CORS headers for allowed browser origins
+  3. SlowAPIMiddleware     -- enforces per-route rate limits from api.limiter
+
+Lifespan handles startup (KEV feed load, cache init, purge task) and
+shutdown (cancel purge task, close DB connection) symmetrically.
 """
 
-# TODO: implement FastAPI app
-# from fastapi import FastAPI
-# from api.routes import cve
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from fastapi.responses import JSONResponse
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+
+from api.limiter import limiter
+from api.models import ErrorDetail, ErrorResponse, HealthResponse
+from api.routes.v1.cve import router as cve_router
+from cache.store import CVECache
+from core.fetcher import fetch_kev
+
+# ---------------------------------------------------------------------------
+# Background purge task
+# ---------------------------------------------------------------------------
+
+
+async def _purge_loop(app: FastAPI) -> None:
+    """Purge expired cache entries every 6 hours.
+
+    Runs as a background asyncio task started in lifespan startup. The
+    while-True loop is intentional: asyncio.sleep yields to the event loop so
+    other coroutines run freely between iterations. CancelledError from
+    task.cancel() during shutdown propagates out of asyncio.sleep and unwinds
+    the coroutine cleanly.
+    """
+    while True:
+        await asyncio.sleep(6 * 60 * 60)
+        app.state.cache.purge_expired()
+
+
+# ---------------------------------------------------------------------------
+# Lifespan -- modern startup / shutdown pattern (replaces @app.on_event)
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Manage application-level resources across the full server lifetime.
+
+    Pattern: asynccontextmanager lifespan. Everything before yield runs on
+    startup; everything after yield runs on shutdown. This is the FastAPI-
+    recommended replacement for the deprecated @app.on_event decorator and
+    guarantees symmetric teardown even if startup raises an exception mid-way.
+
+    Startup order matters:
+      1. KEV feed first -- cheap synchronous HTTP call, data ready before any
+         request arrives.
+      2. Cache second -- depends on nothing, but must exist before the purge
+         task references app.state.cache.
+      3. Purge task last -- references app.state.cache, so cache must exist.
+    """
+    # Startup
+    app.state.kev_set = fetch_kev()
+    app.state.cache = CVECache()
+    app.state.purge_task = asyncio.create_task(_purge_loop(app))
+
+    yield
+
+    # Shutdown
+    app.state.purge_task.cancel()
+    app.state.cache.close()
+
+
+# ---------------------------------------------------------------------------
+# App instantiation
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="VulnAdvisor API",
+    description="CVE triage and remediation guidance. Data from NVD, CISA KEV, EPSS, and PoC-in-GitHub.",
+    version="0.2.0",
+    lifespan=lifespan,
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+# ---------------------------------------------------------------------------
+# Middleware stack
 #
-# app = FastAPI(
-#     title="VulnAdvisor API",
-#     description="CVE triage and remediation guidance",
-#     version="0.2.0",
-# )
-# app.include_router(cve.router)
+# Starlette (FastAPI's foundation) wraps middleware in reverse registration
+# order at the ASGI level, but add_middleware() calls are applied outermost-
+# first from the caller's perspective. Register in the order you want the
+# request to encounter them: TrustedHost -> CORS -> SlowAPI.
+# ---------------------------------------------------------------------------
+
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=["localhost", "127.0.0.1", "*.localhost"],
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost", "http://localhost:3000", "http://127.0.0.1"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type"],
+    max_age=3600,
+)
+
+app.add_middleware(SlowAPIMiddleware)
+
+# Attach the shared limiter to app.state so SlowAPIMiddleware can locate it.
+# SlowAPI looks for app.state.limiter by convention.
+app.state.limiter = limiter
+
+# ---------------------------------------------------------------------------
+# Router registration
+# ---------------------------------------------------------------------------
+
+app.include_router(cve_router, prefix="/api/v1", tags=["CVE Triage"])
+
+# ---------------------------------------------------------------------------
+# Exception handlers
+#
+# All handlers return the same ErrorResponse envelope so API clients can parse
+# errors uniformly without inspecting status codes to choose a schema.
+# ---------------------------------------------------------------------------
+
+
+@app.exception_handler(RateLimitExceeded)
+async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Return 429 with a structured error when a rate limit is exceeded."""
+    return JSONResponse(
+        status_code=429,
+        content=ErrorResponse(
+            error=ErrorDetail(
+                code="rate_limited",
+                message="Too many requests.",
+                detail=str(exc),
+            )
+        ).model_dump(),
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_error_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+    """Return 422 with structured error when request body or query params fail validation."""
+    return JSONResponse(
+        status_code=422,
+        content=ErrorResponse(
+            error=ErrorDetail(
+                code="validation_error",
+                message="Request validation failed.",
+                detail=str(exc.errors()),
+            )
+        ).model_dump(),
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """Return a structured error for all FastAPI/Starlette HTTP exceptions."""
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=ErrorResponse(
+            error=ErrorDetail(
+                code=f"http_{exc.status_code}",
+                message=str(exc.detail),
+            )
+        ).model_dump(),
+    )
+
+
+@app.exception_handler(Exception)
+async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Catch-all handler for unexpected server errors.
+
+    Security note: the raw exception is written to stderr only, never to the
+    response body. Exposing internal stack traces to clients can leak
+    implementation details and aid attackers. The client receives only a
+    generic message.
+    """
+    print(str(exc), file=sys.stderr)
+    return JSONResponse(
+        status_code=500,
+        content=ErrorResponse(
+            error=ErrorDetail(
+                code="internal_error",
+                message="An unexpected error occurred.",
+            )
+        ).model_dump(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Health endpoint
+#
+# Defined directly in main.py (not in a router) so it is always reachable
+# regardless of router registration state. No rate limit applied -- health
+# checks from load balancers and monitoring systems must not be throttled.
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/v1/health", include_in_schema=True, tags=["Health"])
+async def health() -> HealthResponse:
+    """Return API liveness and current version."""
+    return HealthResponse(version="0.2.0")

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,190 @@
+"""
+API request and response models for VulnAdvisor REST endpoints.
+
+These Pydantic v2 models define the HTTP transport contract for the API layer.
+They are intentionally separate from the dataclasses in core/models.py, which
+own the internal domain representation. Route handlers map between the two.
+
+Separation of concerns: core/ models = domain truth; api/ models = API contract.
+"""
+
+from enum import Enum
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from core.models import EnrichedCVE
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CVE_PATTERN = r"^CVE-\d{4}-\d{4,}$"
+
+# Annotated type that applies the CVE pattern to every element in a list.
+# Pydantic v2 validates each item against the constraint when used as list[_CveId].
+_CveId = Annotated[str, Field(pattern=CVE_PATTERN)]
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class ExposureEnum(str, Enum):
+    internet = "internet"
+    internal = "internal"
+    isolated = "isolated"
+
+
+class PriorityEnum(str, Enum):
+    P1 = "P1"
+    P2 = "P2"
+    P3 = "P3"
+    P4 = "P4"
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class BulkRequest(BaseModel):
+    """Request body for POST /api/v1/cve/bulk.
+
+    The field_validator normalizes entries (uppercase, deduplicate) before
+    Pydantic applies the per-item CVE_PATTERN check, so callers may submit
+    lowercase ids or duplicates without receiving a validation error.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    ids: list[_CveId] = Field(
+        min_length=1,
+        max_length=50,
+        description="List of CVE IDs to look up. Min 1, max 50 per request.",
+    )
+
+    @field_validator("ids", mode="before")
+    @classmethod
+    def normalize_ids(cls, values: list) -> list[str]:
+        """Uppercase and deduplicate CVE IDs while preserving original order.
+
+        Runs before Pydantic's per-item pattern validation (mode='before') so
+        the regex fires against the normalized form, not raw user input.
+        """
+        seen: set[str] = set()
+        result: list[str] = []
+        for v in values:
+            normalized = str(v).upper()
+            if normalized not in seen:
+                seen.add(normalized)
+                result.append(normalized)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class CVESummaryRow(BaseModel):
+    """Lightweight summary of a single CVE -- one row in the priority table.
+
+    Excludes full remediation detail. Used in BulkResponse.summary.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    cvss_score: Optional[float]
+    cvss_severity: str
+    is_kev: bool
+    has_poc: bool
+    cwe_name: str
+    triage_priority: str
+    triage_label: str
+
+    @classmethod
+    def from_enriched(cls, cve: EnrichedCVE) -> "CVESummaryRow":
+        """Build a CVESummaryRow from a core EnrichedCVE instance.
+
+        This is the Factory Method pattern -- the mapping lives here, colocated
+        with the output model, rather than scattered across route handlers.
+        """
+        return cls(
+            id=cve.id,
+            cvss_score=cve.cvss.score,
+            cvss_severity=cve.cvss.severity,
+            is_kev=cve.is_kev,
+            has_poc=cve.poc.has_poc,
+            cwe_name=cve.cwe_name,
+            triage_priority=cve.triage_priority,
+            triage_label=cve.triage_label,
+        )
+
+
+class BulkMeta(BaseModel):
+    """Metadata envelope for a bulk CVE response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    requested: int
+    returned: int
+    failed: int
+    exposure: ExposureEnum
+
+
+class BulkResponse(BaseModel):
+    """Response body for POST /api/v1/cve/bulk.
+
+    summary -- priority-bucketed rows (always present).
+    results -- full EnrichedCVE JSON only when the caller passes ?full=true.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    meta: BulkMeta
+    summary: dict[str, list[CVESummaryRow]]
+    results: Optional[list[dict]] = None
+
+
+class SummaryCountResponse(BaseModel):
+    """Response for GET /api/v1/cve/summary.
+
+    Returns a count of CVEs per priority bucket for the requested exposure
+    context, useful for dashboard widgets without fetching full detail.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    counts: dict[str, int]
+    total: int
+    exposure: ExposureEnum
+
+
+class ErrorDetail(BaseModel):
+    """Machine-readable error payload."""
+
+    model_config = ConfigDict(frozen=True)
+
+    code: str
+    message: str
+    detail: Optional[str] = None
+
+
+class ErrorResponse(BaseModel):
+    """Top-level error envelope returned on 4xx/5xx responses."""
+
+    model_config = ConfigDict(frozen=True)
+
+    error: ErrorDetail
+
+
+class HealthResponse(BaseModel):
+    """Response for GET /api/v1/health."""
+
+    model_config = ConfigDict(frozen=True)
+
+    status: str = "ok"
+    version: str

--- a/api/routes/v1/cve.py
+++ b/api/routes/v1/cve.py
@@ -1,0 +1,242 @@
+"""
+api/routes/v1/cve.py -- CVE triage route handlers for the VulnAdvisor REST API.
+
+Route registration order matters here. FastAPI resolves routes in the order
+they are added to the router. The literal paths /cve/summary and /cve/bulk
+must be registered before /cve/{cve_id} or FastAPI will match the strings
+"summary" and "bulk" as CVE ID path parameters, returning 400s instead of
+routing to the correct handlers.
+
+Rate limits are applied via slowapi. The @limiter.limit() decorator must sit
+ABOVE @router.get/post so that slowapi can attach the limit string to the
+function object before FastAPI wraps it.
+"""
+
+import re
+from dataclasses import asdict
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+
+from api.limiter import limiter
+from api.models import (
+    CVE_PATTERN,
+    BulkMeta,
+    BulkRequest,
+    BulkResponse,
+    CVESummaryRow,
+    ErrorDetail,
+    ExposureEnum,
+    PriorityEnum,
+    SummaryCountResponse,
+)
+from core.pipeline import process_cve
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Route 1: GET /cve/summary -- registered FIRST to avoid /{cve_id} capture
+# ---------------------------------------------------------------------------
+
+
+@limiter.limit("30/minute")
+@router.get("/cve/summary", response_model=SummaryCountResponse)
+def get_cve_summary(
+    request: Request,
+    ids: str,
+    exposure: ExposureEnum = ExposureEnum.internal,
+) -> SummaryCountResponse:
+    """Return priority bucket counts for a comma-separated list of CVE IDs.
+
+    Useful for dashboard widgets: returns {"P1": N, "P2": N, ...} rather than
+    full enriched records. Max 50 IDs per request.
+
+    Query params:
+        ids      -- comma-separated CVE IDs (required)
+        exposure -- internet | internal | isolated (default: internal)
+    """
+    # Parse, strip, uppercase, and deduplicate
+    raw_ids = [part.strip().upper() for part in ids.split(",") if part.strip()]
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for cve_id in raw_ids:
+        if cve_id not in seen:
+            seen.add(cve_id)
+            deduped.append(cve_id)
+
+    # Validate each ID against the CVE pattern before touching any external
+    # system. Input validation at the boundary -- never pass unvalidated user
+    # data into URLs or downstream functions.
+    for cve_id in deduped:
+        if not re.match(CVE_PATTERN, cve_id):
+            raise HTTPException(
+                status_code=400,
+                detail=ErrorDetail(
+                    code="invalid_cve_id",
+                    message="Invalid CVE ID format.",
+                    detail=f"{cve_id} does not match CVE-YYYY-NNNNN.",
+                ).model_dump(),
+            )
+
+    # Enforce the 50-ID cap after deduplication
+    if len(deduped) > 50:
+        raise HTTPException(
+            status_code=422,
+            detail=ErrorDetail(
+                code="bulk_limit_exceeded",
+                message="Request exceeds the maximum of 50 CVE IDs.",
+                detail=f"Received {len(deduped)} unique IDs after deduplication.",
+            ).model_dump(),
+        )
+
+    # Fetch and enrich each CVE; skip any that are not found or raise
+    results = []
+    for cve_id in deduped:
+        try:
+            enriched = process_cve(cve_id, request.app.state.kev_set, request.app.state.cache)
+        except ValueError:
+            continue
+        if enriched is not None:
+            results.append(enriched)
+
+    # Bucket counts by triage priority
+    counts: dict[str, int] = {"P1": 0, "P2": 0, "P3": 0, "P4": 0}
+    for enriched in results:
+        priority = enriched.triage_priority
+        if priority in counts:
+            counts[priority] += 1
+
+    return SummaryCountResponse(counts=counts, total=len(results), exposure=exposure)
+
+
+# ---------------------------------------------------------------------------
+# Route 2: POST /cve/bulk -- registered SECOND to avoid /{cve_id} capture
+# ---------------------------------------------------------------------------
+
+
+@limiter.limit("5/minute")
+@router.post("/cve/bulk", response_model=BulkResponse)
+def post_cve_bulk(
+    request: Request,
+    body: BulkRequest,
+    exposure: ExposureEnum = ExposureEnum.internal,
+    full: bool = False,
+    priority_filter: Optional[PriorityEnum] = None,
+) -> BulkResponse:
+    """Look up and enrich a batch of CVE IDs in a single request.
+
+    body.ids is already validated (CVE_PATTERN) and deduplicated by Pydantic
+    before this handler runs -- the BulkRequest field_validator and per-item
+    annotation handle that. No re-validation is needed here.
+
+    Query params:
+        exposure        -- internet | internal | isolated (default: internal)
+        full            -- include full EnrichedCVE JSON alongside summary rows
+        priority_filter -- restrict summary and results to one priority bucket
+    """
+    failed = 0
+    results = []
+
+    for cve_id in body.ids:
+        try:
+            enriched = process_cve(cve_id, request.app.state.kev_set, request.app.state.cache)
+        except ValueError:
+            failed += 1
+            continue
+        if enriched is None:
+            failed += 1
+            continue
+        results.append(enriched)
+
+    # Apply optional priority filter -- narrows both summary and full results
+    if priority_filter is not None:
+        results = [r for r in results if r.triage_priority == priority_filter.value]
+
+    # Build priority-bucketed summary rows
+    summary: dict[str, list[CVESummaryRow]] = {"P1": [], "P2": [], "P3": [], "P4": []}
+    for enriched in results:
+        priority = enriched.triage_priority
+        if priority in summary:
+            summary[priority].append(CVESummaryRow.from_enriched(enriched))
+
+    # Full records only when the caller explicitly requests them
+    full_results: Optional[list[dict]] = [asdict(r) for r in results] if full else None
+
+    return BulkResponse(
+        meta=BulkMeta(
+            requested=len(body.ids),
+            returned=len(results),
+            failed=failed,
+            exposure=exposure,
+        ),
+        summary=summary,
+        results=full_results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route 3: GET /cve/{cve_id} -- registered LAST so literals above win first
+# ---------------------------------------------------------------------------
+
+
+@limiter.limit("30/minute")
+@router.get("/cve/{cve_id}")
+def get_cve(
+    request: Request,
+    cve_id: str,
+    exposure: ExposureEnum = ExposureEnum.internal,
+) -> dict:
+    """Fetch and enrich a single CVE by ID.
+
+    Returns the full EnrichedCVE payload as JSON. The exposure param is
+    accepted for API contract stability but does not yet modify triage
+    priority -- that adjustment is a planned walk-phase feature. Accepting
+    the param now means callers will not need to change their request shape
+    when it lands.
+
+    Path param:
+        cve_id   -- e.g. CVE-2021-44228 (case-insensitive, normalized internally)
+    Query params:
+        exposure -- internet | internal | isolated (default: internal)
+    """
+    normalized = cve_id.upper()
+
+    # Validate format before hitting the pipeline -- never pass unvalidated
+    # user input into the URL substitution inside process_cve / fetch_nvd.
+    if not re.match(CVE_PATTERN, normalized):
+        raise HTTPException(
+            status_code=400,
+            detail=ErrorDetail(
+                code="invalid_cve_id",
+                message="Invalid CVE ID format.",
+                detail=f"{cve_id} does not match CVE-YYYY-NNNNN.",
+            ).model_dump(),
+        )
+
+    # process_cve raises ValueError for format problems that slip past the
+    # regex above (defensive). Convert to 400 so the caller gets a clear
+    # error rather than an unhandled 500.
+    try:
+        result = process_cve(normalized, request.app.state.kev_set, request.app.state.cache)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=ErrorDetail(
+                code="invalid_cve_id",
+                message=str(exc),
+            ).model_dump(),
+        ) from exc
+
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=ErrorDetail(
+                code="cve_not_found",
+                message=f"{normalized} was not found in NVD.",
+            ).model_dump(),
+        )
+
+    # asdict() converts the EnrichedCVE dataclass (and all nested dataclasses)
+    # to a plain dict that FastAPI's JSON serializer handles natively.
+    return asdict(result)

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -1,0 +1,72 @@
+"""
+core/pipeline.py — Pure CVE fetch-cache-enrich pipeline.
+
+No side effects. No print statements. Designed to be called by both
+the CLI (via main.py) and the REST API (via api/routes/v1/cve.py).
+"""
+
+import re
+from typing import Optional
+
+from cache.store import CVECache
+from core.enricher import enrich
+from core.fetcher import fetch_epss, fetch_nvd, fetch_poc
+from core.models import EnrichedCVE
+
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$")
+
+
+def process_cve(cve_id: str, kev_set: set[str], cache: Optional[CVECache] = None) -> Optional[EnrichedCVE]:
+    """Fetch, cache, and enrich a single CVE. Returns None if the CVE is not found.
+
+    Raises ValueError if cve_id does not match the expected format.
+    No print statements — all side effects belong to the caller.
+    """
+    cve_id = cve_id.strip().upper()
+
+    if not _CVE_RE.match(cve_id):
+        raise ValueError(f"Invalid CVE ID format: {cve_id}")
+
+    if cache is not None:
+        cached = cache.get(cve_id)
+        if cached is not None:
+            return enrich(cached["cve_raw"], kev_set, cached["epss_data"], cached["poc_data"])
+
+    cve_raw = fetch_nvd(cve_id)
+    if cve_raw is None:
+        return None
+
+    epss_data = fetch_epss(cve_id)
+    poc_data = fetch_poc(cve_id)
+
+    if cache is not None:
+        cache.set(cve_id, {"cve_raw": cve_raw, "epss_data": epss_data, "poc_data": poc_data})
+
+    return enrich(cve_raw, kev_set, epss_data, poc_data)
+
+
+def process_cves(cve_ids: list[str], kev_set: set[str], cache: Optional[CVECache] = None) -> list[EnrichedCVE]:
+    """Process a list of CVE IDs and return all successfully enriched results.
+
+    Deduplicates input (case-insensitive, preserving first-occurrence order).
+    Silently skips any ID that raises ValueError or produces no NVD record.
+    No print statements — all side effects belong to the caller.
+    """
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for cve_id in cve_ids:
+        normalized = cve_id.strip().upper()
+        if normalized not in seen:
+            seen.add(normalized)
+            deduped.append(cve_id)
+
+    results: list[EnrichedCVE] = []
+    for cve_id in deduped:
+        try:
+            enriched = process_cve(cve_id, kev_set, cache)
+        except ValueError:
+            continue
+        if enriched is not None:
+            results.append(enriched)
+
+    return results

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,2 +1,3 @@
 fastapi==0.115.6
 uvicorn[standard]==0.34.0
+slowapi==0.1.9


### PR DESCRIPTION
- Extract process_cve/process_cves into core/pipeline.py (pure, no side effects)
- Add api/limiter.py: shared slowapi Limiter with in-memory counter store
- Add api/models.py: Pydantic v2 request/response models (BulkRequest, BulkResponse, CVESummaryRow, ErrorResponse, HealthResponse, etc.)
- Implement api/main.py: FastAPI app with lifespan, TrustedHost/CORS/SlowAPI middleware, consistent error envelope on all 4xx/5xx, and /health endpoint
- Add api/routes/v1/cve.py: three rate-limited endpoints
    GET  /api/v1/cve/summary   (30/min) - priority bucket counts
    POST /api/v1/cve/bulk      (5/min)  - batch lookup with optional ?full and ?priority_filter
    GET  /api/v1/cve/{cve_id}  (30/min) - single CVE full report
- Update requirements-api.txt: add slowapi==0.1.9
- Update README.md: document all API endpoints, rate limits, error format, and curl examples