### PR TITLE
feat: security hardening, exposure-aware triage, and export formats

### DIFF
--- a/api/routes/v1/cve.py
+++ b/api/routes/v1/cve.py
@@ -14,9 +14,9 @@ function object before FastAPI wraps it.
 
 import re
 from dataclasses import asdict
-from typing import Optional
+from typing import Annotated, Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from api.limiter import limiter
 from api.models import (
@@ -44,7 +44,7 @@ router = APIRouter()
 @router.get("/cve/summary", response_model=SummaryCountResponse)
 def get_cve_summary(
     request: Request,
-    ids: str,
+    ids: Annotated[str, Query(max_length=2000)],
     exposure: ExposureEnum = ExposureEnum.internal,
 ) -> SummaryCountResponse:
     """Return priority bucket counts for a comma-separated list of CVE IDs.
@@ -75,7 +75,7 @@ def get_cve_summary(
                 detail=ErrorDetail(
                     code="invalid_cve_id",
                     message="Invalid CVE ID format.",
-                    detail=f"{cve_id} does not match CVE-YYYY-NNNNN.",
+                    detail=f"{cve_id[:50]} does not match CVE-YYYY-NNNNN.",
                 ).model_dump(),
             )
 
@@ -210,7 +210,7 @@ def get_cve(
             detail=ErrorDetail(
                 code="invalid_cve_id",
                 message="Invalid CVE ID format.",
-                detail=f"{cve_id} does not match CVE-YYYY-NNNNN.",
+                detail=f"{cve_id[:50]} does not match CVE-YYYY-NNNNN.",
             ).model_dump(),
         )
 

--- a/core/fetcher.py
+++ b/core/fetcher.py
@@ -3,6 +3,7 @@ fetcher.py — All external data fetching.
 All sources are free and require no API keys.
 """
 
+import threading
 from typing import Any, Optional
 
 import requests
@@ -12,13 +13,28 @@ CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_v
 EPSS_API = "https://api.first.org/data/v1/epss"
 POC_GITHUB = "https://raw.githubusercontent.com/nomi-sec/PoC-in-GitHub/master/{year}/{cve_id}.json"
 
+# Module-level session shared across all fetcher calls for connection pooling.
+# max_redirects=3 replaces the requests default of 30 — these are known public APIs,
+# 3 hops is generous and protects against open redirect / SSRF via redirect chains.
+_session = requests.Session()
+_session.max_redirects = 3
+
 _kev_cache: Optional[set[str]] = None
+_kev_lock = threading.Lock()
 
 
-def fetch_nvd(cve_id: str) -> Optional[dict[str, Any]]:
-    """Fetch raw CVE record from NVD."""
+def fetch_nvd(cve_id: str, api_key: Optional[str] = None) -> Optional[dict[str, Any]]:
+    """Fetch raw CVE record from NVD.
+
+    Args:
+        cve_id:  CVE identifier, e.g. "CVE-2021-44228".
+        api_key: Optional NVD API key (header: apiKey). Raises rate limit from
+                 5 req/min (unauthenticated) to 50 req/min (authenticated).
+                 Free registration at https://nvd.nist.gov/developers/request-an-api-key
+    """
     try:
-        resp = requests.get(NVD_API, params={"cveId": cve_id}, timeout=10)
+        headers = {"apiKey": api_key} if api_key else {}
+        resp = _session.get(NVD_API, params={"cveId": cve_id}, headers=headers, timeout=10)
         resp.raise_for_status()
         vulns = resp.json().get("vulnerabilities", [])
         return vulns[0].get("cve") if vulns else None
@@ -28,26 +44,32 @@ def fetch_nvd(cve_id: str) -> Optional[dict[str, Any]]:
 
 
 def fetch_kev() -> set[str]:
-    """Fetch CISA Known Exploited Vulnerabilities catalog (cached for session)."""
+    """Fetch CISA Known Exploited Vulnerabilities catalog (cached for session).
+
+    Thread-safe via double-checked locking: check under lock, fetch outside lock
+    (network I/O must not block other threads), write result under lock.
+    """
     global _kev_cache
-    if _kev_cache is not None:
-        return _kev_cache
+    with _kev_lock:
+        if _kev_cache is not None:
+            return _kev_cache
     try:
-        resp = requests.get(CISA_KEV_URL, timeout=10)
+        resp = _session.get(CISA_KEV_URL, timeout=10)
         resp.raise_for_status()
         entries = resp.json().get("vulnerabilities", [])
-        _kev_cache = {e["cveID"] for e in entries}
-        return _kev_cache
+        kev_set: set[str] = {e["cveID"] for e in entries}
     except requests.RequestException:
         print("  [!] Could not fetch CISA KEV feed — skipping exploit status check.")
-        _kev_cache = set()
-        return _kev_cache
+        kev_set = set()
+    with _kev_lock:
+        _kev_cache = kev_set
+    return kev_set
 
 
 def fetch_epss(cve_id: str) -> dict[str, Any]:
     """Fetch EPSS exploitation probability score from FIRST.org."""
     try:
-        resp = requests.get(EPSS_API, params={"cve": cve_id}, timeout=10)
+        resp = _session.get(EPSS_API, params={"cve": cve_id}, timeout=10)
         resp.raise_for_status()
         data = resp.json().get("data", [])
         if data:
@@ -68,7 +90,7 @@ def fetch_poc(cve_id: str) -> dict[str, Any]:
     try:
         year = cve_id.split("-")[1]
         url = POC_GITHUB.format(year=year, cve_id=cve_id)
-        resp = requests.get(url, timeout=10)
+        resp = _session.get(url, timeout=10)
         if resp.status_code == 404:
             return {"has_poc": False, "count": 0, "sources": []}
         resp.raise_for_status()

--- a/core/formatter.py
+++ b/core/formatter.py
@@ -2,12 +2,71 @@
 formatter.py — Renders EnrichedCVE to terminal output or JSON.
 """
 
+import csv
+import html
+import io
 import json
+import os
+import re
+import sys
 from dataclasses import asdict
+from datetime import date
+from typing import Optional
 
 from .models import EnrichedCVE
 
 W = 68  # output width
+
+# ---------------------------------------------------------------------------
+# ANSI color control
+# ---------------------------------------------------------------------------
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from a string."""
+    return _ANSI_RE.sub("", text)
+
+
+def _use_color() -> bool:
+    """Return True if stdout is a TTY and color has not been disabled.
+
+    Respects NO_COLOR env var (https://no-color.org) and checks sys.stdout.isatty().
+    Can be overridden by calling disable_color() / enable_color().
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+_color_enabled: Optional[bool] = None  # None = auto-detect
+
+
+def disable_color() -> None:
+    """Force-disable color output (called when --no-color flag is set)."""
+    global _color_enabled
+    _color_enabled = False
+
+
+def enable_color() -> None:
+    """Force-enable color output (called when --color=always is set)."""
+    global _color_enabled
+    _color_enabled = True
+
+
+def _color_active() -> bool:
+    """Check if color is currently active."""
+    if _color_enabled is not None:
+        return _color_enabled
+    return _use_color()
+
+
+# ---------------------------------------------------------------------------
+# ANSI code helpers — return empty string when color is off
+# ---------------------------------------------------------------------------
 
 PRIORITY_COLORS = {
     "P1": "\033[91m",  # red
@@ -15,16 +74,41 @@ PRIORITY_COLORS = {
     "P3": "\033[94m",  # blue
     "P4": "\033[92m",  # green
 }
-RESET = "\033[0m"
-BOLD = "\033[1m"
 
 
-def _bar(char="═") -> str:
+def _reset() -> str:
+    return "\033[0m" if _color_active() else ""
+
+
+def _bold() -> str:
+    return "\033[1m" if _color_active() else ""
+
+
+def _dim() -> str:
+    return "\033[2m" if _color_active() else ""
+
+
+def _red() -> str:
+    return "\033[91m" if _color_active() else ""
+
+
+def _p_color(priority: str) -> str:
+    return PRIORITY_COLORS.get(priority, "") if _color_active() else ""
+
+
+# ---------------------------------------------------------------------------
+# Layout helpers
+# ---------------------------------------------------------------------------
+
+
+def _bar(char: str = "═") -> str:
     return char * W
 
 
 def _section(title: str) -> str:
-    return f"\n  {BOLD}{title}{RESET}\n  {'─' * (W - 2)}"
+    bold = _bold()
+    reset = _reset()
+    return f"\n  {bold}{title}{reset}\n  {'─' * (W - 2)}"
 
 
 def _wrap(text: str, indent: int = 4, width: int = W) -> str:
@@ -43,26 +127,34 @@ def _wrap(text: str, indent: int = 4, width: int = W) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Terminal renderer
+# ---------------------------------------------------------------------------
+
+
 def print_terminal(cve: EnrichedCVE) -> None:
-    p_color = PRIORITY_COLORS.get(cve.triage_priority, "")
+    bold = _bold()
+    reset = _reset()
+    red = _red()
+    p_color = _p_color(cve.triage_priority)
 
-    # ── Header ──────────────────────────────────────────────────────────────
-    print(f"\n{BOLD}{_bar()}{RESET}")
-    kev_tag = f"  {BOLD}\033[91m*** ACTIVELY EXPLOITED ***{RESET}" if cve.is_kev else ""
-    print(f"  {BOLD}{cve.id}{RESET}  │  CVSS {cve.cvss.score} {cve.cvss.severity}{kev_tag}")
-    print(f"{BOLD}{_bar()}{RESET}")
+    # -- Header ---------------------------------------------------------------
+    print(f"\n{bold}{_bar()}{reset}")
+    kev_tag = f"  {bold}{red}*** ACTIVELY EXPLOITED ***{reset}" if cve.is_kev else ""
+    print(f"  {bold}{cve.id}{reset}  │  CVSS {cve.cvss.score} {cve.cvss.severity}{kev_tag}")
+    print(f"{bold}{_bar()}{reset}")
 
-    # ── Triage Priority ─────────────────────────────────────────────────────
+    # -- Triage Priority ------------------------------------------------------
     print(_section("TRIAGE PRIORITY"))
-    print(f"    {p_color}{BOLD}{cve.triage_priority} — {cve.triage_label}{RESET}")
+    print(f"    {p_color}{bold}{cve.triage_priority} — {cve.triage_label}{reset}")
     print(f"    {cve.triage_reason}")
 
-    # ── Threat Snapshot ─────────────────────────────────────────────────────
+    # -- Threat Snapshot ------------------------------------------------------
     print(_section("THREAT SNAPSHOT"))
     score_str = f"{cve.cvss.score}/10" if cve.cvss.score else "N/A"
     print(f"    CVSS Score     {score_str} ({cve.cvss.severity})")
 
-    kev_val = f"\033[91m{BOLD}YES — On CISA Known Exploited List{RESET}" if cve.is_kev else "No"
+    kev_val = f"{red}{bold}YES — On CISA Known Exploited List{reset}" if cve.is_kev else "No"
     print(f"    Actively Exploited  {kev_val}")
 
     if cve.epss_score is not None:
@@ -70,10 +162,10 @@ def print_terminal(cve: EnrichedCVE) -> None:
         tile = round(cve.epss_percentile * 100, 1) if cve.epss_percentile else 0
         print(f"    Exploit Probability  {pct}%  (higher than {tile}% of all CVEs)")
 
-    poc_val = f"\033[91m{BOLD}YES — {cve.poc.count} public repo(s) found{RESET}" if cve.poc.has_poc else "None found"
+    poc_val = f"{red}{bold}YES — {cve.poc.count} public repo(s) found{reset}" if cve.poc.has_poc else "None found"
     print(f"    Public PoC     {poc_val}")
 
-    # ── What Is It ──────────────────────────────────────────────────────────
+    # -- What Is It -----------------------------------------------------------
     print(_section("WHAT IS IT?"))
     if cve.cwe_plain:
         print(f"    Type:  {cve.cwe_name}")
@@ -82,7 +174,7 @@ def print_terminal(cve: EnrichedCVE) -> None:
     print()
     print(_wrap(cve.description))
 
-    # ── How Can It Be Attacked ───────────────────────────────────────────────
+    # -- How Can It Be Attacked -----------------------------------------------
     print(_section("HOW CAN IT BE ATTACKED?"))
     cvss = cve.cvss
     for label, val in [
@@ -95,7 +187,7 @@ def print_terminal(cve: EnrichedCVE) -> None:
         if val:
             print(f"    {label:<22}  {val}")
 
-    # ── Impact ──────────────────────────────────────────────────────────────
+    # -- Impact ---------------------------------------------------------------
     print(_section("WHAT COULD AN ATTACKER DO?"))
     for label, val in [
         ("Data confidentiality", cvss.confidentiality),
@@ -105,37 +197,37 @@ def print_terminal(cve: EnrichedCVE) -> None:
         if val and val != "NONE":
             print(f"    {label:<26} {val} impact")
 
-    # ── Affected Products ────────────────────────────────────────────────────
+    # -- Affected Products ----------------------------------------------------
     if cve.affected_products:
         print(_section("AFFECTED PRODUCTS"))
         for product in cve.affected_products[:6]:
             print(f"    • {product}")
 
-    # ── What To Do ──────────────────────────────────────────────────────────
+    # -- What To Do -----------------------------------------------------------
     print(_section("WHAT DO I DO?"))
     for i, step in enumerate(cve.remediation, 1):
         tag = f"[{step.action:<10}]"
-        print(f"\n    {i}. {BOLD}{tag}{RESET}")
+        print(f"\n    {i}. {bold}{tag}{reset}")
         print(_wrap(step.description, indent=8))
 
-    # ── Compensating Controls ────────────────────────────────────────────────
+    # -- Compensating Controls ------------------------------------------------
     if cve.compensating_controls:
         print(_section("IF PATCHING IS NOT IMMEDIATE"))
         print("    Reduce risk with these controls while you work toward a fix.\n")
         for control in cve.compensating_controls:
             print(_wrap(f"• {control}", indent=4))
         if cve.sigma_link:
-            DIM = "\033[2m"
-            print(f"\n    {DIM}Detection rules (Sigma): {cve.sigma_link}{RESET}")
+            dim = _dim()
+            print(f"\n    {dim}Detection rules (Sigma): {cve.sigma_link}{reset}")
 
-    # ── PoC Sources ─────────────────────────────────────────────────────────
+    # -- PoC Sources ----------------------------------------------------------
     if cve.poc.sources:
         print(_section("PUBLIC PROOF-OF-CONCEPT REPOS"))
         print("    These are real exploit demos — patch before attackers use them.\n")
         for src in cve.poc.sources:
             print(f"    • {src}")
 
-    # ── References ──────────────────────────────────────────────────────────
+    # -- References -----------------------------------------------------------
     patch_refs = [r for r in cve.references if any(t in ("Patch", "Vendor Advisory", "Mitigation") for t in r.tags)]
     if patch_refs:
         print(_section("PATCH / ADVISORY REFERENCES"))
@@ -149,6 +241,11 @@ def print_terminal(cve: EnrichedCVE) -> None:
     print(f"\n{_bar()}\n")
 
 
+# ---------------------------------------------------------------------------
+# Summary table renderer
+# ---------------------------------------------------------------------------
+
+
 def print_summary(cves: list[EnrichedCVE]) -> None:
     """Print a prioritized summary table for a list of CVEs — P1 first, P4 last."""
     PRIORITY_ORDER = ["P1", "P2", "P3", "P4"]
@@ -159,38 +256,229 @@ def print_summary(cves: list[EnrichedCVE]) -> None:
         "P4": "Next patch cycle",
     }
 
+    bold = _bold()
+    reset = _reset()
+    red = _red()
+
     by_priority: dict[str, list[EnrichedCVE]] = {p: [] for p in PRIORITY_ORDER}
     for cve in cves:
         by_priority.setdefault(cve.triage_priority, []).append(cve)
 
-    print(f"\n{BOLD}{_bar()}{RESET}")
-    print(f"  {BOLD}PRIORITY SUMMARY — {len(cves)} CVEs analysed{RESET}")
-    print(f"{BOLD}{_bar()}{RESET}")
+    print(f"\n{bold}{_bar()}{reset}")
+    print(f"  {bold}PRIORITY SUMMARY — {len(cves)} CVEs analysed{reset}")
+    print(f"{bold}{_bar()}{reset}")
 
     for priority in PRIORITY_ORDER:
         group = by_priority.get(priority, [])
         if not group:
             continue
 
-        p_color = PRIORITY_COLORS.get(priority, "")
+        p_color = _p_color(priority)
         label = PRIORITY_LABELS.get(priority, "")
         header = f"{priority} — {label}"
         count = f"({len(group)})"
-        print(f"\n  {p_color}{BOLD}{header:<46}{count}{RESET}")
+        print(f"\n  {p_color}{bold}{header:<46}{count}{reset}")
         print(f"  {'─' * (W - 2)}")
 
         for cve in group:
             score = f"{cve.cvss.score:.1f}" if cve.cvss.score else " N/A"
             severity = cve.cvss.severity[:8]
-            kev_tag = f"{BOLD}\033[91mKEV{RESET}" if cve.is_kev else "   "
-            poc_tag = f"{BOLD}\033[91mPoC{RESET}" if cve.poc.has_poc else "   "
+            kev_tag = f"{bold}{red}KEV{reset}" if cve.is_kev else "   "
+            poc_tag = f"{bold}{red}PoC{reset}" if cve.poc.has_poc else "   "
             cwe = cve.cwe_name[:30] if cve.cwe_name else "Unknown"
             print(f"  {cve.id:<18} {score:>4}  {severity:<9} {kev_tag}  {poc_tag}  {cwe}")
 
     print(f"\n{_bar()}\n")
 
 
+# ---------------------------------------------------------------------------
+# JSON export
+# ---------------------------------------------------------------------------
+
+
 def to_json(cve: EnrichedCVE) -> str:
     """Return a JSON-serializable dict — ready for future API use."""
     d = asdict(cve)
     return json.dumps(d, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CSV export
+# ---------------------------------------------------------------------------
+
+
+def to_csv(results: list) -> str:
+    """Render a list of EnrichedCVE as CSV.
+
+    Columns: id, triage_priority, triage_label, cvss_score, cvss_severity,
+             is_kev, epss_score, has_poc, poc_count, cwe_id, cwe_name,
+             affected_products_count, remediation_summary
+    """
+    headers = [
+        "id",
+        "triage_priority",
+        "triage_label",
+        "cvss_score",
+        "cvss_severity",
+        "is_kev",
+        "epss_score",
+        "has_poc",
+        "poc_count",
+        "cwe_id",
+        "cwe_name",
+        "affected_products_count",
+        "remediation_summary",
+    ]
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(headers)
+
+    for r in results:
+        # Build remediation summary: prefer first PATCH step, else first of any type.
+        remediation_summary = ""
+        patch_steps = [s for s in r.remediation if s.action.upper() == "PATCH"]
+        if patch_steps:
+            remediation_summary = patch_steps[0].description
+        elif r.remediation:
+            remediation_summary = r.remediation[0].description
+        remediation_summary = remediation_summary[:120]
+
+        writer.writerow(
+            [
+                r.id,
+                r.triage_priority,
+                r.triage_label,
+                r.cvss.score if r.cvss.score is not None else "",
+                r.cvss.severity,
+                r.is_kev,
+                r.epss_score if r.epss_score is not None else "",
+                r.poc.has_poc,
+                r.poc.count,
+                r.cwe_id or "",
+                r.cwe_name,
+                len(r.affected_products),
+                remediation_summary,
+            ]
+        )
+
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# HTML export
+# ---------------------------------------------------------------------------
+
+_PRIORITY_HTML_COLORS = {
+    "P1": "#dc2626",
+    "P2": "#ea580c",
+    "P3": "#ca8a04",
+    "P4": "#16a34a",
+}
+
+_HTML_STYLE = """
+    body { font-family: Arial, sans-serif; margin: 32px; background: #f9fafb; color: #111827; }
+    h1 { font-size: 1.5rem; margin-bottom: 4px; }
+    p.subtitle { color: #6b7280; margin-top: 0; margin-bottom: 24px; font-size: 0.9rem; }
+    table { border-collapse: collapse; width: 100%; background: #ffffff; }
+    th { background: #1f2937; color: #f9fafb; text-align: left; padding: 10px 12px; font-size: 0.85rem; }
+    td { padding: 9px 12px; font-size: 0.85rem; border-bottom: 1px solid #e5e7eb; vertical-align: middle; }
+    tr:nth-child(even) td { background: #f3f4f6; }
+    tr:hover td { background: #eff6ff; }
+    .badge {
+        display: inline-block; padding: 2px 10px; border-radius: 12px;
+        color: #ffffff; font-weight: bold; font-size: 0.8rem;
+    }
+    .check { color: #16a34a; font-weight: bold; }
+    .dash  { color: #9ca3af; }
+"""
+
+
+def to_html(results: list) -> str:
+    """Render a list of EnrichedCVE as a self-contained HTML report.
+
+    Suitable for saving as .html and opening in a browser, or attaching to email.
+    No external CSS or JS dependencies -- all styles are inline.
+    """
+    today = date.today().isoformat()
+    rows_html = []
+
+    for r in results:
+        badge_color = _PRIORITY_HTML_COLORS.get(r.triage_priority, "#6b7280")
+        badge = f'<span class="badge" style="background:{badge_color}">' f"{html.escape(r.triage_priority)}</span>"
+        cve_id = html.escape(r.id)
+        score = f"{r.cvss.score:.1f}" if r.cvss.score is not None else "N/A"
+        kev = '<span class="check">&#10003;</span>' if r.is_kev else '<span class="dash">-</span>'
+        poc = '<span class="check">&#10003;</span>' if r.poc.has_poc else '<span class="dash">-</span>'
+        epss = f"{round(r.epss_score * 100, 1)}%" if r.epss_score is not None else "-"
+        cwe_name = html.escape(r.cwe_name) if r.cwe_name else "-"
+        triage_label = html.escape(r.triage_label)
+
+        rows_html.append(
+            f"    <tr>"
+            f"<td>{badge}</td>"
+            f"<td>{cve_id}</td>"
+            f"<td>{score}</td>"
+            f"<td>{kev}</td>"
+            f"<td>{poc}</td>"
+            f"<td>{epss}</td>"
+            f"<td>{cwe_name}</td>"
+            f"<td>{triage_label}</td>"
+            f"</tr>"
+        )
+
+    rows = "\n".join(rows_html)
+
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '  <meta charset="UTF-8">\n'
+        '  <meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "  <title>VulnAdvisor &mdash; CVE Triage Report</title>\n"
+        f"  <style>{_HTML_STYLE}  </style>\n"
+        "</head>\n"
+        "<body>\n"
+        "  <h1>VulnAdvisor &mdash; CVE Triage Report</h1>\n"
+        f'  <p class="subtitle">Generated {today} &nbsp;&bull;&nbsp; {len(results)} CVE(s)</p>\n'
+        "  <table>\n"
+        "    <thead>\n"
+        "      <tr>\n"
+        "        <th>Priority</th><th>CVE ID</th><th>CVSS</th>"
+        "<th>KEV</th><th>PoC</th><th>EPSS</th><th>CWE</th><th>Triage Label</th>\n"
+        "      </tr>\n"
+        "    </thead>\n"
+        "    <tbody>\n"
+        f"{rows}\n"
+        "    </tbody>\n"
+        "  </table>\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown export
+# ---------------------------------------------------------------------------
+
+
+def to_markdown(results: list) -> str:
+    """Render a list of EnrichedCVE as a Markdown summary table.
+
+    Suitable for Slack, GitHub issues, and documentation.
+    """
+    header = "| Priority | CVE ID | CVSS | KEV | PoC | EPSS | Triage Label |"
+    separator = "|----------|--------|------|-----|-----|------|--------------|"
+    lines = [header, separator]
+
+    for r in results:
+        score = f"{r.cvss.score:.1f}" if r.cvss.score is not None else "N/A"
+        kev = "Yes" if r.is_kev else "No"
+        poc = "Yes" if r.poc.has_poc else "No"
+        epss = f"{round(r.epss_score * 100, 1)}%" if r.epss_score is not None else "-"
+        # Escape pipe characters in any free-text field to avoid breaking table layout.
+        triage_label = r.triage_label.replace("|", "\\|")
+        cve_id = r.id.replace("|", "\\|")
+        lines.append(f"| {r.triage_priority} | {cve_id} | {score} | {kev} | {poc} | {epss} | {triage_label} |")
+
+    return "\n".join(lines) + "\n"

--- a/core/models.py
+++ b/core/models.py
@@ -28,6 +28,7 @@ class PoCInfo:
 class RemediationStep:
     action: str  # PATCH | WORKAROUND | REFERENCE
     description: str
+    priority: str = "RECOMMENDED"
 
 
 @dataclass

--- a/main.py
+++ b/main.py
@@ -9,25 +9,42 @@ Usage:
   python main.py --file cves.txt
   python main.py --file cves.txt --full
   python main.py CVE-2021-44228 --json
+  python main.py CVE-2021-44228 --format csv
+  python main.py CVE-2021-44228 --exposure internet
   python main.py CVE-2021-44228 --no-cache
+  python main.py CVE-2021-44228 --no-color
+
+Environment variables:
+  NVD_API_KEY   Optional NVD API key. Raises rate limit from 5 req/min to 50 req/min.
+                Free registration at https://nvd.nist.gov/developers/request-an-api-key
 """
 
 import argparse
+import os
 import re
 from pathlib import Path
 from typing import Optional
 
 from cache.store import CVECache
 from core.fetcher import fetch_kev
-from core.formatter import print_summary, print_terminal, to_json
+from core.formatter import disable_color, print_summary, print_terminal, to_csv, to_html, to_json, to_markdown
 from core.models import EnrichedCVE
 from core.pipeline import process_cve
 
 
 def _load_file(path: str) -> list[str]:
-    """Read CVE IDs from a file — one per line, # comments and blank lines ignored."""
+    """Read CVE IDs from a file — one per line, # comments and blank lines ignored.
+
+    Resolves symlinks and verifies the path is a regular file before reading.
+    This prevents accidental reads from FIFOs, devices, or traversal into
+    unexpected locations when the function is called programmatically.
+    """
+    file_path = Path(path).resolve()
+    if not file_path.is_file():
+        print(f"  [!] '{path}' is not a readable file.")
+        return []
     try:
-        lines = Path(path).read_text().splitlines()
+        lines = file_path.read_text().splitlines()
     except OSError as e:
         print(f"  [!] Could not read file '{path}': {e}")
         return []
@@ -37,7 +54,13 @@ def _load_file(path: str) -> list[str]:
 _CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$")
 
 
-def fetch_and_enrich(cve_id: str, kev_set: set[str], cache: Optional[CVECache] = None) -> Optional[EnrichedCVE]:
+def fetch_and_enrich(
+    cve_id: str,
+    kev_set: set[str],
+    cache: Optional[CVECache] = None,
+    exposure: str = "internal",
+    nvd_api_key: Optional[str] = None,
+) -> Optional[EnrichedCVE]:
     """Fetch and enrich a single CVE. Returns None on failure.
 
     Delegates all pipeline logic to core.pipeline.process_cve. This function
@@ -47,7 +70,7 @@ def fetch_and_enrich(cve_id: str, kev_set: set[str], cache: Optional[CVECache] =
 
     if cache is not None and cache.get(cve_id) is not None:
         print(f"  {cve_id} (cached)")
-        return process_cve(cve_id, kev_set, cache)
+        return process_cve(cve_id, kev_set, cache, exposure=exposure, nvd_api_key=nvd_api_key)
 
     if not _CVE_RE.match(cve_id):
         print(f"  [!] '{cve_id}' doesn't look like a valid CVE ID. Expected format: CVE-YYYY-NNNNN")
@@ -55,7 +78,7 @@ def fetch_and_enrich(cve_id: str, kev_set: set[str], cache: Optional[CVECache] =
 
     print(f"  Fetching {cve_id}...", end=" ", flush=True)
 
-    result = process_cve(cve_id, kev_set, cache)
+    result = process_cve(cve_id, kev_set, cache, exposure=exposure, nvd_api_key=nvd_api_key)
 
     if result is None:
         print(f"\n  [!] No NVD record found for {cve_id}. Check the ID and try again.")
@@ -77,6 +100,10 @@ Examples:
   python main.py --file cves.txt
   python main.py --file cves.txt --full
   python main.py CVE-2021-44228 --json
+  python main.py CVE-2021-44228 --format csv > report.csv
+  python main.py CVE-2021-44228 --format html > report.html
+  python main.py CVE-2021-44228 --exposure internet
+  NVD_API_KEY=your-key python main.py --file cves.txt
         """,
     )
     parser.add_argument(
@@ -91,6 +118,14 @@ Examples:
         help="Path to a text file with one CVE ID per line (# comments supported)",
     )
     parser.add_argument(
+        "--exposure",
+        choices=["internet", "internal", "isolated"],
+        default="internal",
+        metavar="CONTEXT",
+        help="Asset exposure context: internet, internal, or isolated (default: internal). "
+        "Adjusts triage priority based on attack surface.",
+    )
+    parser.add_argument(
         "--full",
         action="store_true",
         help="Print the full report for every CVE after the priority summary",
@@ -98,7 +133,19 @@ Examples:
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Output structured JSON instead of terminal display",
+        help="Output structured JSON (shorthand for --format json)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["terminal", "json", "csv", "html", "markdown"],
+        default=None,
+        metavar="FORMAT",
+        help="Output format: terminal (default), json, csv, html, or markdown",
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI color codes in terminal output",
     )
     parser.add_argument(
         "--no-cache",
@@ -107,19 +154,43 @@ Examples:
     )
     args = parser.parse_args()
 
-    # Collect and deduplicate CVE IDs from args and/or file
+    # Apply color preference before any output
+    if args.no_color:
+        disable_color()
+
+    # Resolve output format — --json is a backward-compatible alias for --format json
+    output_format = args.format or ("json" if args.json else "terminal")
+
+    # Read NVD API key from environment
+    nvd_api_key: Optional[str] = os.environ.get("NVD_API_KEY") or None
+
+    # Collect CVE IDs from args and/or file, with deduplication reporting
     all_ids: list[str] = list(args.cves)
+    file_ids: list[str] = []
     if args.file:
-        all_ids.extend(_load_file(args.file))
+        file_ids = _load_file(args.file)
+        all_ids.extend(file_ids)
+
     seen: set[str] = set()
-    cve_ids = [x for x in all_ids if not (x.upper() in seen or seen.add(x.upper()))]  # type: ignore[func-returns-value]
+    cve_ids: list[str] = []
+    for x in all_ids:
+        if x.upper() not in seen:
+            seen.add(x.upper())
+            cve_ids.append(x)
 
     if not cve_ids:
         parser.print_help()
         return
 
+    # Report deduplication when loading from file
+    if args.file and len(all_ids) != len(cve_ids):
+        dupes = len(all_ids) - len(cve_ids)
+        print(f"  Loaded {len(all_ids)} IDs, {dupes} duplicate(s) removed, {len(cve_ids)} unique.\n")
+
     print("\nVulnAdvisor — CVE Triage Tool")
     print("─" * 40)
+    if nvd_api_key:
+        print("NVD API key loaded (50 req/min).")
     print("Loading CISA Known Exploited Vulnerabilities feed...", end=" ", flush=True)
     kev_set = fetch_kev()
     print(f"{len(kev_set)} entries loaded.\n")
@@ -128,31 +199,42 @@ Examples:
 
     results: list[EnrichedCVE] = []
     for cve_id in cve_ids:
-        enriched = fetch_and_enrich(cve_id, kev_set, cache)
+        enriched = fetch_and_enrich(cve_id, kev_set, cache, exposure=args.exposure, nvd_api_key=nvd_api_key)
         if enriched:
             results.append(enriched)
 
     if not results:
         return
 
-    if args.json:
+    # Output
+    if output_format == "json":
+        import json
+
         if len(results) == 1:
             print(to_json(results[0]))
         else:
-            import json
-
             print(json.dumps([json.loads(to_json(r)) for r in results], indent=2))
-        return
 
-    if len(results) == 1:
-        print_terminal(results[0])
+    elif output_format == "csv":
+        print(to_csv(results))
+
+    elif output_format == "html":
+        print(to_html(results))
+
+    elif output_format == "markdown":
+        print(to_markdown(results))
+
     else:
-        print_summary(results)
-        if args.full:
-            for enriched in results:
-                print_terminal(enriched)
+        # terminal (default)
+        if len(results) == 1:
+            print_terminal(results[0])
         else:
-            print("\n  Run with --full to see the complete report for each CVE.\n")
+            print_summary(results)
+            if args.full:
+                for enriched in results:
+                    print_terminal(enriched)
+            else:
+                print("\n  Run with --full to see the complete report for each CVE.\n")
 
     if len(cve_ids) > len(results):
         failed = len(cve_ids) - len(results)


### PR DESCRIPTION
Security:
- core/fetcher.py: limit HTTP redirects to 3 hops (SSRF mitigation), add threading.Lock on _kev_cache (race condition fix), add NVD API key support via fetch_nvd(api_key=) for 50 req/min vs 5 unauthenticated
- api/routes/v1/cve.py: max_length=2000 on ids query param (DoS mitigation), truncate user input to 50 chars in error messages (info disclosure fix)
- api/main.py: add Retry-After header to 429 rate limit responses
- main.py: resolve symlinks and verify is_file() before reading --file input
- core/enricher.py: narrow bare except Exception to specific types (ValueError, KeyError, IndexError, TypeError) in CVSS parser

Exposure-aware triage:
- core/enricher.py: add exposure param to _triage_priority() and enrich(); isolated assets downgrade priority by one level (KEV never downgraded); internet-facing assets with PoC/EPSS upgrade P2/P3 by one level
- core/pipeline.py: thread exposure and nvd_api_key through process_cve/process_cves
- main.py: add --exposure {internet,internal,isolated} CLI flag (default: internal)

Export formats:
- core/formatter.py: add to_csv(), to_html(), to_markdown(); add strip_ansi(), TTY-aware color detection, disable_color()/enable_color() controls; existing ANSI codes guarded by _color_active() so piped/CI output is clean
- main.py: add --format {terminal,json,csv,html,markdown} flag; --json kept as backward-compatible alias; add --no-color flag; read NVD_API_KEY env var; report dedup count when --file removes duplicates

Data quality:
- core/models.py: add priority field to RemediationStep (CRITICAL/RECOMMENDED/OPTIONAL)
- core/enricher.py: set RemediationStep.priority by action type; remove silent [:5] patch version cap from extraction layer; add version range display ("Product 2.0.0 through 3.1.2" instead of just "Product")