### PR TITLE
fix: log warning on CVSS parse failure instead of silent pass

### DIFF
--- a/core/enricher.py
+++ b/core/enricher.py
@@ -3,9 +3,12 @@ enricher.py — Takes raw fetched data and enriches it into a structured,
 plain-language EnrichedCVE ready for output.
 """
 
+import logging
 from typing import Optional
 
 from .models import CVSSDetails, EnrichedCVE, PoCInfo, Reference, RemediationStep
+
+_log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # CWE — plain-language name, description, and generic remediation
@@ -315,8 +318,8 @@ def _parse_cvss_vector(vector: str, details: CVSSDetails) -> None:
         IndexError,
         TypeError,
         AttributeError,
-    ):  # noqa: S110  # nosec B110 — malformed CVSS vectors produce empty fields
-        pass
+    ) as e:
+        _log.warning("CVSS vector parse failed: vector=%r error=%s", vector, e)
 
 
 def _extract_cvss(cve: dict) -> CVSSDetails:

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -320,10 +320,21 @@ class TestParseCvssVector:
         assert details.attack_vector == ""
 
     def test_none_vector_does_not_raise(self):
-        # TypeError/AttributeError from None.split() is caught by the broad except clause
+        # TypeError from None.split() is caught and logged; fields remain empty
         details = CVSSDetails()
         _parse_cvss_vector(None, details)  # type: ignore[arg-type]
         assert details.attack_vector == ""
+
+    def test_malformed_vector_logs_warning(self, caplog):
+        """Malformed CVSS vector should log a WARNING, not raise."""
+        import logging
+
+        details = CVSSDetails()
+        with caplog.at_level(logging.WARNING, logger="core.enricher"):
+            _parse_cvss_vector(None, details)
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+        assert "CVSS vector parse failed" in caplog.records[0].message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `import logging` and module-level `_log = logging.getLogger(__name__)` to enricher.py
- Changes the `except (...): pass` in `_parse_cvss_vector` to `except (...) as e: _log.warning(...)`
- Removes the now-stale `# noqa: S110 / # nosec B110` suppression comments (they suppressed the "bare pass" warning, which no longer applies)
- Adds `test_malformed_vector_logs_warning` using pytest `caplog` to verify a WARNING fires on bad input

## Why
Silent `except: pass` caused data loss with no diagnostics. Any malformed CVSS vector in NVD data silently produced an empty `CVSSDetails` with no indication of why. A logged warning makes this visible in production logs without breaking the call flow.

**Pattern used:** `logging.getLogger(__name__)` at module level is the canonical Python logging pattern. The logger name resolves to `core.enricher` at runtime, which integrates cleanly with the logging hierarchy and lets operators filter per module.

## Files changed
- `core/enricher.py` — add logging setup; capture and log exception in `_parse_cvss_vector`
- `tests/test_enricher.py` — update stale comment; add caplog warning test

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)