### PR TITLE
feat: add authentication layer (JWT, OAuth, API keys)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ run-file: ## Triage CVEs from a file  (usage: make run-file FILE=cves.txt)
 	$(PYTHON) main.py --file $(FILE)
 
 run-api: ## Start the API server  (walk phase)
-	uvicorn api.main:app --reload --host 0.0.0.0 --port 8000
+	uvicorn asgi:app --reload --host 0.0.0.0 --port 8000
 
 # ── Clean ─────────────────────────────────────────────────────────────────────
 

--- a/api/routes/v1/assets.py
+++ b/api/routes/v1/assets.py
@@ -22,7 +22,7 @@ File uploads:
 
 import re
 
-from fastapi import APIRouter, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
 from sqlalchemy.exc import IntegrityError
 
 from api.limiter import limiter
@@ -37,12 +37,16 @@ from api.models import (
     ErrorDetail,
     IngestResponse,
 )
+from auth.dependencies import get_current_user
 from cmdb.ingest import IngestRecord, parse_csv, parse_grype_json, parse_nessus_csv, parse_trivy_json
 from cmdb.models import Asset, AssetVulnerability
 from cmdb.store import CMDBStore, apply_criticality_modifier
 from core.pipeline import process_cves
 
-router = APIRouter()
+# All asset and ingest routes require authentication.
+# Router-level dependency applies to every route registered on this router,
+# so individual handlers don't each need to repeat Depends(get_current_user).
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 _MAX_UPLOAD_BYTES = 1 * 1024 * 1024  # 1 MB
 

--- a/api/routes/v1/auth.py
+++ b/api/routes/v1/auth.py
@@ -1,0 +1,351 @@
+"""
+api/routes/v1/auth.py -- Authentication and user management REST endpoints.
+
+Routes:
+  POST /api/v1/auth/login              -- password login; sets JWT cookie
+  POST /api/v1/auth/logout             -- clears cookie; 200
+  GET  /api/v1/auth/me                 -- current user info (requires auth)
+  GET  /api/v1/auth/providers          -- list enabled OAuth providers (public)
+  POST /api/v1/auth/api-keys           -- create API key (requires auth)
+  GET  /api/v1/auth/api-keys           -- list user's API keys (requires auth)
+  DELETE /api/v1/auth/api-keys/{id}   -- revoke key (requires auth, ownership checked)
+  POST /api/v1/auth/users              -- create user (admin only)
+  GET  /api/v1/auth/users              -- list all users (admin only)
+  PATCH /api/v1/auth/users/{id}        -- update role/is_active (admin only)
+
+Security:
+  [H2] POST /login is rate-limited to 10 requests/minute per IP.
+  [C1] authenticate_user() provides timing equalization -- use it, never inline.
+  [M4] PATCH /users/{id} blocks self-deactivation and last-admin-deactivation.
+  [M5] Cache-Control: no-store on login responses.
+  IDOR guard: DELETE /api-keys/{id} passes user_id to store; the store checks ownership.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+
+from api.limiter import limiter
+from api.models import (
+    ApiKeyCreate,
+    ApiKeyCreatedResponse,
+    ApiKeyResponse,
+    LoginRequest,
+    LoginResponse,
+    MeResponse,
+    OAuthProviderInfo,
+    UserCreate,
+    UserPatch,
+    UserResponse,
+)
+from auth.dependencies import get_current_user, require_admin
+from auth.models import ApiKey, User
+from auth.oauth import get_enabled_providers
+from auth.store import UserStore
+from auth.tokens import (
+    authenticate_user,
+    create_access_token,
+    generate_api_key,
+    hash_api_key,
+    hash_password,
+    set_auth_cookie,
+)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Public endpoints
+# ---------------------------------------------------------------------------
+
+
+@limiter.limit("10/minute")  # [H2] brute-force mitigation -- must be ABOVE @router to preserve FastAPI introspection
+@router.post("/auth/login", response_model=LoginResponse)
+def login(request: Request, body: LoginRequest) -> JSONResponse:
+    """Authenticate with username and password; set JWT cookie.
+
+    Uses authenticate_user() which includes timing equalization [C1]. Do NOT
+    inline get_by_username() + verify_password() -- that re-introduces the
+    timing attack.
+
+    Returns the same generic error for wrong username and wrong password
+    ("bad_credentials") to avoid leaking username existence information.
+    """
+    user_store: UserStore = request.app.state.user_store
+    user = authenticate_user(user_store, body.username, body.password)
+    if user is None:
+        resp = JSONResponse(
+            status_code=401,
+            content={"error": {"code": "bad_credentials", "message": "Invalid username or password."}},
+        )
+        resp.headers["Cache-Control"] = "no-store"  # [M5]
+        return resp
+
+    token = create_access_token(user.id, user.username, user.role)
+    resp = JSONResponse(
+        status_code=200,
+        content=LoginResponse(
+            access_token=token,
+            token_type="bearer",  # noqa: S106 # nosec B106 -- OAuth token type, not a password
+            expires_in=8 * 3600,
+            username=user.username,
+            role=user.role,
+        ).model_dump(),
+    )
+    set_auth_cookie(resp, token)
+    resp.headers["Cache-Control"] = "no-store"  # [M5]
+    return resp
+
+
+@router.post("/auth/logout")
+async def logout() -> JSONResponse:
+    """Clear the JWT cookie and end the session."""
+    resp = JSONResponse(content={"message": "Logged out."})
+    resp.delete_cookie("access_token")
+    return resp
+
+
+@router.get("/auth/providers", response_model=list[OAuthProviderInfo])
+async def list_providers() -> list[OAuthProviderInfo]:
+    """Return the list of configured OAuth providers.
+
+    Public endpoint -- the login page calls this to decide which provider
+    buttons to render. Returns an empty list if no OAuth env vars are set.
+    """
+    return [OAuthProviderInfo(**p) for p in get_enabled_providers()]
+
+
+# ---------------------------------------------------------------------------
+# Authenticated endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/auth/me", response_model=MeResponse)
+async def me(current_user: User = Depends(get_current_user)) -> MeResponse:
+    """Return identity information for the currently authenticated user."""
+    return MeResponse(
+        user_id=current_user.id,
+        username=current_user.username,
+        role=current_user.role,
+        oauth_provider=current_user.oauth_provider,
+    )
+
+
+# ---------------------------------------------------------------------------
+# API key management (authenticated)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/auth/api-keys", response_model=ApiKeyCreatedResponse, status_code=201)
+async def create_api_key(
+    request: Request,
+    body: ApiKeyCreate,
+    current_user: User = Depends(get_current_user),
+) -> ApiKeyCreatedResponse:
+    """Generate a new API key. The raw key is shown ONCE and never stored.
+
+    [H3] Enforces a cap of 10 active keys per user. This prevents abuse
+    (e.g. a compromised account creating unlimited keys) and makes it
+    practical to audit keys during incident response.
+    """
+    user_store: UserStore = request.app.state.user_store
+
+    existing = user_store.get_api_keys(current_user.id)
+    if len(existing) >= 10:  # [H3]
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "key_limit_reached",
+                "message": "Maximum of 10 API keys per user. Revoke an existing key first.",
+            },
+        )
+
+    raw_key = generate_api_key()
+    key_hash = hash_api_key(raw_key)
+    key_prefix = raw_key[:12]
+
+    api_key = ApiKey(
+        user_id=current_user.id,
+        name=body.name,
+        key_hash=key_hash,
+        key_prefix=key_prefix,
+    )
+    key_id = user_store.create_api_key(api_key)
+
+    return ApiKeyCreatedResponse(
+        id=key_id,
+        name=body.name,
+        key_prefix=key_prefix,
+        created_at="",  # store sets this; fetch fresh record for accurate value
+        last_used=None,
+        key=raw_key,
+    )
+
+
+@router.get("/auth/api-keys", response_model=list[ApiKeyResponse])
+async def list_api_keys(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+) -> list[ApiKeyResponse]:
+    """List all active API keys for the current user. Raw key values are never returned."""
+    user_store: UserStore = request.app.state.user_store
+    keys = user_store.get_api_keys(current_user.id)
+    return [
+        ApiKeyResponse(
+            id=k.id,
+            name=k.name,
+            key_prefix=k.key_prefix,
+            created_at=k.created_at or "",
+            last_used=k.last_used,
+        )
+        for k in keys
+    ]
+
+
+@router.delete("/auth/api-keys/{key_id}", status_code=204)
+async def revoke_api_key(
+    request: Request,
+    key_id: int,
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    """Revoke an API key. Ownership is verified server-side [IDOR guard].
+
+    Passes both key_id and current_user.id to the store. The store's WHERE
+    clause requires both to match, so an analyst cannot revoke another user's
+    key even if they know its ID.
+    """
+    user_store: UserStore = request.app.state.user_store
+    revoked = user_store.revoke_api_key(key_id, current_user.id)
+    if not revoked:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "not_found", "message": "API key not found."},
+        )
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# User management (admin only)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/auth/users", response_model=UserResponse, status_code=201)
+async def create_user(
+    request: Request,
+    body: UserCreate,
+    current_user: User = Depends(require_admin),
+) -> UserResponse:
+    """Create a new user account. Admin only.
+
+    Admins pre-create accounts before users log in. For OAuth users, set
+    username to the user's provider email. For local users, a password is
+    required.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    user_store: UserStore = request.app.state.user_store
+
+    hashed_pw: str | None = None
+    if body.password:
+        hashed_pw = hash_password(body.password)
+
+    new_user = User(
+        username=body.username,
+        role=body.role,
+        hashed_password=hashed_pw,
+    )
+    try:
+        user_id = user_store.create_user(new_user)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "conflict", "message": "A user with that username already exists."},
+        ) from exc
+
+    created = user_store.get_by_id(user_id)
+    return _user_to_response(created)
+
+
+@router.get("/auth/users", response_model=list[UserResponse])
+async def list_users(
+    request: Request,
+    current_user: User = Depends(require_admin),
+) -> list[UserResponse]:
+    """List all user accounts. Admin only."""
+    user_store: UserStore = request.app.state.user_store
+    users = user_store.list_users()
+    return [_user_to_response(u) for u in users]
+
+
+@router.patch("/auth/users/{user_id}", response_model=UserResponse)
+async def update_user(
+    request: Request,
+    user_id: int,
+    body: UserPatch,
+    current_user: User = Depends(require_admin),
+) -> UserResponse:
+    """Update a user's role or active status. Admin only.
+
+    [M4] Prevents:
+      - Self-deactivation (admin accidentally locking themselves out).
+      - Deactivating the last active admin (no recovery path without DB access).
+    """
+    user_store: UserStore = request.app.state.user_store
+
+    target = user_store.get_by_id(user_id)
+    if target is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "not_found", "message": "User not found."},
+        )
+
+    updates: dict = {}
+    if body.role is not None:
+        updates["role"] = body.role
+    if body.is_active is not None:
+        # [M4] Block self-deactivation
+        if not body.is_active and target.id == current_user.id:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "self_deactivation", "message": "You cannot deactivate your own account."},
+            )
+        # [M4] Block deactivating the last admin
+        if not body.is_active and target.role == "admin":
+            if user_store.count_active_admins() <= 1:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"code": "last_admin", "message": "Cannot deactivate the last active admin account."},
+                )
+        updates["is_active"] = body.is_active
+
+    if not updates:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "no_changes", "message": "No fields to update."},
+        )
+
+    user_store.update_user(user_id, **updates)
+    updated = user_store.get_by_id(user_id)
+    return _user_to_response(updated)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _user_to_response(user: User | None) -> UserResponse:
+    if user is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"code": "internal_error", "message": "User not found after write."},
+        )
+    return UserResponse(
+        id=user.id,
+        username=user.username,
+        role=user.role,
+        oauth_provider=user.oauth_provider,
+        is_active=user.is_active,
+        created_at=user.created_at or "",
+    )

--- a/api/routes/v1/dashboard.py
+++ b/api/routes/v1/dashboard.py
@@ -9,13 +9,14 @@ Returns a single payload suitable for driving dashboard widgets:
 This is a read-only aggregate route -- no mutations here.
 """
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
 from api.limiter import limiter
 from api.models import DashboardResponse
+from auth.dependencies import get_current_user
 from cmdb.store import CMDBStore
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 
 @limiter.limit("60/minute")

--- a/asgi.py
+++ b/asgi.py
@@ -1,0 +1,17 @@
+"""
+asgi.py -- Application assembly for VulnAdvisor.
+
+This is the ONLY file that imports from both api/ and web/. It joins the two
+independent layers into a single ASGI app without coupling them to each other.
+api/main.py knows nothing about web/; web/routes.py knows nothing about api/.
+
+Run with:  uvicorn asgi:app --reload
+           make run-api
+"""
+
+from api.main import app
+from web.routes import router as web_router
+
+# Mount the web UI router here, not in api/main.py.
+# This keeps api/ and web/ independent -- neither imports from the other.
+app.include_router(web_router, tags=["Web UI"])

--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,6 @@
+"""auth/ -- Authentication and authorization package for VulnAdvisor.
+
+Layer rule: auth/ imports only stdlib + third-party libraries.
+It does NOT import from api/, web/, core/, cmdb/, or cache/.
+api/ and web/ import from auth/, not the other way around.
+"""

--- a/auth/dependencies.py
+++ b/auth/dependencies.py
@@ -1,0 +1,101 @@
+"""
+auth/dependencies.py -- FastAPI Depends() helpers for authentication.
+
+Three auth methods are checked in priority order:
+  1. JWT cookie ("access_token") -- set by the web UI login flow.
+  2. Authorization: Bearer <token> header -- API clients using JWTs.
+  3. X-API-Key header -- CI/CD and scripts using long-lived API keys.
+
+All three methods converge on a User object after successful verification.
+
+try_get_current_user() is the soft variant (returns None on failure).
+get_current_user() wraps it and raises HTTP 401 if unauthenticated.
+require_admin() wraps get_current_user() and raises HTTP 403 if not admin.
+
+Layer rule: no imports from web/, core/, cmdb/, or cache/.
+  auth/dependencies.py may import from fastapi (for Depends/HTTPException/Request)
+  because this module is part of the FastAPI dependency injection system.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from auth.models import User
+from auth.tokens import decode_access_token, hash_api_key
+
+
+def try_get_current_user(request: Request) -> User | None:
+    """Attempt to authenticate the request via cookie, Bearer, or API key.
+
+    Returns the authenticated User on success, None on any failure.
+    Never raises -- callers that need a hard 401 should use get_current_user().
+
+    Auth method priority:
+      1. JWT cookie -- set by the web UI login (httpOnly, samesite=lax).
+      2. Authorization: Bearer header -- for API clients using JWTs.
+      3. X-API-Key header -- for CI/CD and scripts.
+    """
+    user_store = request.app.state.user_store
+
+    # 1. Cookie (web UI)
+    token: str | None = request.cookies.get("access_token")
+
+    # 2. Authorization: Bearer header (API clients)
+    if not token:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+
+    # Validate JWT (from cookie or Bearer header)
+    if token:
+        payload = decode_access_token(token)
+        if payload:
+            user = user_store.get_by_id(payload["user_id"])
+            if user and user.is_active:
+                return user
+
+    # 3. X-API-Key header (CI/CD, scripts)
+    raw_key = request.headers.get("X-API-Key", "")
+    if raw_key:
+        key_hash = hash_api_key(raw_key)
+        key = user_store.get_api_key_by_hash(key_hash)
+        if key and key.is_active:
+            user = user_store.get_by_id(key.user_id)
+            if user and user.is_active:
+                user_store.update_api_key_last_used(key.id)
+                return user
+
+    return None
+
+
+def get_current_user(request: Request) -> User:
+    """Require authentication. Raises HTTP 401 if the request is not authenticated.
+
+    Use as a FastAPI dependency:
+        @router.get("/protected")
+        async def route(user: User = Depends(get_current_user)): ...
+    """
+    user = try_get_current_user(request)
+    if user is None:
+        raise HTTPException(
+            status_code=401,
+            detail={"code": "unauthorized", "message": "Authentication required."},
+        )
+    return user
+
+
+def require_admin(request: Request) -> User:
+    """Require admin role. Raises HTTP 401 if unauthenticated, HTTP 403 if not admin.
+
+    Use as a FastAPI dependency:
+        @router.post("/admin-only")
+        async def route(user: User = Depends(require_admin)): ...
+    """
+    user = get_current_user(request)
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "forbidden", "message": "Admin access required."},
+        )
+    return user

--- a/auth/models.py
+++ b/auth/models.py
@@ -1,0 +1,64 @@
+"""
+auth/models.py -- Domain dataclasses for authentication entities.
+
+Pattern: Data class (pure data container, zero logic). Mirrors the approach
+in core/models.py and cmdb/models.py -- dataclasses own domain shape; stores
+and routes do the work.
+
+Layer rule: no imports from api/, web/, core/, cmdb/, or cache/.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class User:
+    """Represents an authenticated identity in VulnAdvisor.
+
+    username doubles as the email address for OAuth users -- the pre-created
+    record uses the provider email as username so the OAuth callback can match
+    by get_by_username(email) before the oauth_subject is linked.
+
+    hashed_password is None for OAuth-only users (they have no local password).
+    oauth_provider / oauth_subject are None until the user logs in via OAuth for
+    the first time, at which point link_oauth() fills them in.
+
+    user_preferences is a JSON blob reserved for Phase 3 dashboard customization.
+    """
+
+    username: str
+    role: str  # "admin", "analyst", "viewer"
+    id: int | None = None
+    hashed_password: str | None = None  # None = OAuth-only user
+    oauth_provider: str | None = None  # "github", "google", "oidc"
+    oauth_subject: str | None = None  # provider's stable user ID
+    user_preferences: str | None = None  # JSON blob (Phase 3 dashboard config)
+    created_at: str | None = None
+    is_active: bool = True
+
+
+@dataclass
+class ApiKey:
+    """A long-lived credential for non-browser API clients (CI/CD, scripts).
+
+    Security design:
+    - key_hash is HMAC-SHA256(SECRET_KEY, raw_key). Deterministic hash lets the
+      store do an O(1) lookup without bcrypt's intentional slowness.  Long random
+      keys (256-bit entropy) make brute-force attacks infeasible -- the strength
+      requirement bcrypt satisfies for low-entropy passwords is unnecessary here.
+    - key_prefix (first 12 chars of the raw key) is stored for display purposes
+      only. Users can identify which key is which without exposing the full value.
+    - The raw key is never persisted. It is returned ONCE at creation and then
+      unrecoverable. Users must rotate if lost.
+    """
+
+    user_id: int
+    name: str
+    key_hash: str  # HMAC-SHA256 of the raw key
+    key_prefix: str  # first 12 chars of raw key, display only
+    id: int | None = None
+    created_at: str | None = None
+    last_used: str | None = None
+    is_active: bool = True

--- a/auth/oauth.py
+++ b/auth/oauth.py
@@ -1,0 +1,209 @@
+"""
+auth/oauth.py -- Authlib OAuth/OIDC provider configuration.
+
+Reads environment variables at module load to decide which providers are
+active. Only providers with both client ID and secret configured get
+registered -- the login template renders buttons dynamically based on
+get_enabled_providers().
+
+Security notes:
+  [H1] Email verification is mandatory. get_oauth_user_info() raises ValueError
+       if the provider does not confirm the email is verified. An unverified
+       email from GitHub could belong to an attacker who added a victim's
+       address without confirming it.
+
+  OAuth state parameter (CSRF protection) is handled by authlib automatically
+  via Starlette SessionMiddleware. The session stores the state between the
+  authorization redirect and the callback -- never trust state from query params
+  alone.
+
+Supported providers:
+  github -- Authorization code flow; static endpoints.
+  google -- Authorization code flow; OIDC discovery.
+  oidc   -- Generic OIDC discovery (Okta, Azure AD, Keycloak, Authentik, etc.)
+
+Layer rule: no imports from api/, web/, core/, cmdb/, or cache/.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from authlib.integrations.starlette_client import OAuth
+
+logger = logging.getLogger("vulnadvisor.auth.oauth")
+
+# ---------------------------------------------------------------------------
+# Authlib OAuth registry
+# ---------------------------------------------------------------------------
+
+oauth = OAuth()
+
+# GitHub -- static endpoints (no OIDC discovery document)
+_GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID", "")
+_GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
+if _GITHUB_CLIENT_ID and _GITHUB_CLIENT_SECRET:
+    oauth.register(
+        name="github",
+        client_id=_GITHUB_CLIENT_ID,
+        client_secret=_GITHUB_CLIENT_SECRET,
+        access_token_url="https://github.com/login/oauth/access_token",  # noqa: S106 -- URL, not a password
+        authorize_url="https://github.com/login/oauth/authorize",
+        api_base_url="https://api.github.com/",
+        client_kwargs={"scope": "read:user user:email"},
+    )
+    logger.info("GitHub OAuth provider registered")
+
+# Google -- OIDC discovery
+_GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
+_GOOGLE_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
+if _GOOGLE_CLIENT_ID and _GOOGLE_CLIENT_SECRET:
+    oauth.register(
+        name="google",
+        client_id=_GOOGLE_CLIENT_ID,
+        client_secret=_GOOGLE_CLIENT_SECRET,
+        server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+        client_kwargs={"scope": "openid email profile"},
+    )
+    logger.info("Google OAuth provider registered")
+
+# Generic OIDC -- Okta, Azure AD, Keycloak, Authentik, etc.
+_OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", "")
+_OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", "")
+_OIDC_DISCOVERY_URL = os.environ.get("OIDC_DISCOVERY_URL", "")
+_OIDC_DISPLAY_NAME = os.environ.get("OIDC_DISPLAY_NAME", "SSO")
+if _OIDC_CLIENT_ID and _OIDC_CLIENT_SECRET and _OIDC_DISCOVERY_URL:
+    oauth.register(
+        name="oidc",
+        client_id=_OIDC_CLIENT_ID,
+        client_secret=_OIDC_CLIENT_SECRET,
+        server_metadata_url=_OIDC_DISCOVERY_URL,
+        client_kwargs={"scope": "openid email profile"},
+    )
+    logger.info("Generic OIDC provider registered (display name: %s)", _OIDC_DISPLAY_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Provider metadata
+# ---------------------------------------------------------------------------
+
+
+def get_enabled_providers() -> list[dict]:
+    """Return metadata for every configured OAuth provider.
+
+    Used by GET /api/v1/auth/providers and the login template to render
+    provider buttons dynamically. Only providers with both env vars set are
+    included.
+
+    Returns list of {"name": str, "label": str} dicts.
+    """
+    providers: list[dict] = []
+    if _GITHUB_CLIENT_ID and _GITHUB_CLIENT_SECRET:
+        providers.append({"name": "github", "label": "GitHub"})
+    if _GOOGLE_CLIENT_ID and _GOOGLE_CLIENT_SECRET:
+        providers.append({"name": "google", "label": "Google"})
+    if _OIDC_CLIENT_ID and _OIDC_CLIENT_SECRET and _OIDC_DISCOVERY_URL:
+        providers.append({"name": "oidc", "label": _OIDC_DISPLAY_NAME})
+    return providers
+
+
+# ---------------------------------------------------------------------------
+# Email / subject extraction -- provider-specific normalization [H1]
+# ---------------------------------------------------------------------------
+
+
+async def get_oauth_user_info(client, provider: str, token: dict) -> tuple[str, str]:
+    """Extract (email, subject_id) from a provider token response.
+
+    Normalizes the provider-specific response formats into a common interface.
+
+    [H1] SECURITY: Email verification is checked before returning. An unverified
+    email could be a victim's address added by an attacker. If the provider does
+    not confirm verification, or returns no primary verified email, raises
+    ValueError -- the caller must treat this as an authentication failure and
+    redirect to /login?error=oauth_failed.
+
+    Args:
+        client:   The authlib OAuth client for this provider.
+        provider: "github", "google", or "oidc".
+        token:    The token dict returned by authlib after code exchange.
+
+    Returns:
+        (email, subject_id) -- both are stable identifiers for this user.
+
+    Raises:
+        ValueError: If a verified email cannot be confirmed.
+    """
+    if provider == "github":
+        return await _get_github_user_info(client, token)
+    elif provider in ("google", "oidc"):
+        return _get_oidc_user_info(token, provider)
+    else:
+        raise ValueError(f"Unknown OAuth provider: {provider!r}")
+
+
+async def _get_github_user_info(client, token: dict) -> tuple[str, str]:
+    """Extract (email, subject_id) from a GitHub token.
+
+    GitHub does not include the email in the access token. Two API calls are
+    required:
+      1. GET /user -- to get the numeric user ID (stable subject).
+      2. GET /user/emails -- to find the primary verified email.
+
+    [H1] Only the email where both primary=true AND verified=true is accepted.
+    If no such entry exists, raises ValueError.
+    """
+    # Fetch the user profile for the numeric ID
+    resp = await client.get("user", token=token)
+    resp.raise_for_status()
+    profile = resp.json()
+    subject_id = str(profile["id"])
+
+    # Fetch emails and find primary verified one
+    emails_resp = await client.get("user/emails", token=token)
+    emails_resp.raise_for_status()
+    emails = emails_resp.json()
+
+    email: str | None = None
+    for entry in emails:
+        if entry.get("primary") and entry.get("verified"):
+            email = entry["email"]
+            break
+
+    if not email:
+        raise ValueError(
+            "GitHub OAuth: no primary verified email found. "
+            "The user must verify their email address on GitHub before logging in."
+        )
+
+    return email, subject_id
+
+
+def _get_oidc_user_info(token: dict, provider: str) -> tuple[str, str]:
+    """Extract (email, subject_id) from a Google/OIDC id_token.
+
+    Both Google and generic OIDC providers return an id_token whose claims
+    include email, email_verified, and sub (subject ID).
+
+    [H1] The email claim is only accepted when email_verified is True.
+    Some OIDC providers omit email_verified entirely -- we treat that as
+    unverified and raise ValueError.
+    """
+    userinfo = token.get("userinfo")
+    if not userinfo:
+        raise ValueError(f"{provider} OAuth: no userinfo in token response")
+
+    if not userinfo.get("email_verified", False):
+        raise ValueError(
+            f"{provider} OAuth: email is not verified. "
+            "The provider must confirm email ownership before login is allowed."
+        )
+
+    email = userinfo.get("email")
+    subject_id = userinfo.get("sub")
+
+    if not email or not subject_id:
+        raise ValueError(f"{provider} OAuth: missing email or sub claim in userinfo")
+
+    return email, subject_id

--- a/auth/store.py
+++ b/auth/store.py
@@ -1,0 +1,299 @@
+"""
+auth/store.py -- SQLAlchemy Core persistence layer for auth entities.
+
+Pattern: Repository + Data Mapper (same as cmdb/store.py).
+UserStore is the repository; _row_to_user / _row_to_api_key are the mappers.
+Route and dependency code never touches SQL directly.
+
+Security:
+  All queries use bound parameters. No f-strings in SQL.
+
+  UNIQUE(oauth_provider, oauth_subject) is enforced in code rather than SQL
+  because SQLite treats two NULL values as distinct in UNIQUE constraints,
+  which would allow duplicate unlinked records. The code-level check in
+  link_oauth() handles this correctly.
+
+DB path: auth/vulnadvisor_auth.db (sibling to cmdb/vulnadvisor_cmdb.db).
+
+Layer rule: no imports from api/, web/, core/, cmdb/, or cache/.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import Column, Integer, MetaData, String, Table, Text, create_engine, text
+from sqlalchemy.engine import Engine
+
+from auth.models import ApiKey, User
+
+_DEFAULT_DB_URL = f"sqlite:///{Path(__file__).parent / 'vulnadvisor_auth.db'}"
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_metadata = MetaData()
+
+_users = Table(
+    "users",
+    _metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("username", String(255), nullable=False, unique=True),
+    Column("hashed_password", Text),  # NULL for OAuth-only users
+    Column("role", String(30), nullable=False, server_default="analyst"),
+    Column("oauth_provider", String(30)),  # "github", "google", "oidc"
+    Column("oauth_subject", Text),  # provider's stable user ID
+    Column("user_preferences", Text),  # JSON blob (Phase 3)
+    Column("created_at", String(32), nullable=False),
+    Column("is_active", Integer, nullable=False, server_default="1"),
+    # Note: UNIQUE(oauth_provider, oauth_subject) enforced in code, not SQL.
+    # SQLite treats two NULLs as distinct in UNIQUE constraints, which would
+    # allow duplicate unlinked records for users who haven't yet done OAuth.
+)
+
+_api_keys = Table(
+    "api_keys",
+    _metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column("user_id", Integer, nullable=False),
+    Column("name", String(100), nullable=False),
+    Column("key_hash", String(64), nullable=False, unique=True),  # HMAC-SHA256 hex
+    Column("key_prefix", String(12), nullable=False),  # first 12 chars, display only
+    Column("created_at", String(32), nullable=False),
+    Column("last_used", String(32)),
+    Column("is_active", Integer, nullable=False, server_default="1"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Repository
+# ---------------------------------------------------------------------------
+
+
+class UserStore:
+    """Repository for User and ApiKey entities.
+
+    Usage:
+        store = UserStore()
+        store.create_user(User(username="admin", role="admin", hashed_password=hash_password("secret")))
+        user = store.get_by_username("admin")
+        store.close()
+    """
+
+    def __init__(self, db_url: str = _DEFAULT_DB_URL) -> None:
+        connect_args: dict = {}
+        if db_url.startswith("sqlite"):
+            connect_args["check_same_thread"] = False
+        self.engine: Engine = create_engine(db_url, connect_args=connect_args)
+        _metadata.create_all(self.engine)
+
+    # ------------------------------------------------------------------
+    # User queries
+    # ------------------------------------------------------------------
+
+    def has_users(self) -> bool:
+        """Return True if at least one user record exists.
+
+        Used by the setup redirect middleware and POST /setup to detect
+        first-run state. Must be cheap -- uses COUNT(*) with early exit.
+        """
+        with self.engine.connect() as conn:
+            result = conn.execute(text("SELECT COUNT(*) FROM users")).scalar()
+        return (result or 0) > 0
+
+    def create_user(self, user: User) -> int:
+        """Insert a new user and return its assigned database ID.
+
+        Raises sqlalchemy.exc.IntegrityError if the username already exists.
+        Callers (e.g. POST /setup) should catch IntegrityError as a signal
+        that a concurrent request already created the record [M1].
+        """
+        with self.engine.connect() as conn:
+            result = conn.execute(
+                _users.insert().values(
+                    username=user.username,
+                    hashed_password=user.hashed_password,
+                    role=user.role,
+                    oauth_provider=user.oauth_provider,
+                    oauth_subject=user.oauth_subject,
+                    user_preferences=user.user_preferences,
+                    created_at=_now_iso(),
+                    is_active=1 if user.is_active else 0,
+                )
+            )
+            conn.commit()
+            return result.inserted_primary_key[0]
+
+    def get_by_username(self, username: str) -> User | None:
+        """Look up a user by exact username (case-sensitive). Returns None if not found."""
+        with self.engine.connect() as conn:
+            row = conn.execute(_users.select().where(_users.c.username == username)).fetchone()
+        return _row_to_user(row) if row is not None else None
+
+    def get_by_id(self, user_id: int) -> User | None:
+        """Look up a user by primary key. Returns None if not found."""
+        with self.engine.connect() as conn:
+            row = conn.execute(_users.select().where(_users.c.id == user_id)).fetchone()
+        return _row_to_user(row) if row is not None else None
+
+    def get_by_oauth(self, provider: str, subject: str) -> User | None:
+        """Look up a user by (oauth_provider, oauth_subject) pair.
+
+        Returns None if no linked record exists. The OAuth callback uses this
+        after the first successful login links an identity; subsequent logins
+        find the user instantly via this method.
+        """
+        with self.engine.connect() as conn:
+            row = conn.execute(
+                _users.select().where((_users.c.oauth_provider == provider) & (_users.c.oauth_subject == subject))
+            ).fetchone()
+        return _row_to_user(row) if row is not None else None
+
+    def link_oauth(self, user_id: int, provider: str, subject: str) -> None:
+        """Associate an OAuth identity with an existing user record.
+
+        Called on first OAuth login when a pre-created user (matched by email)
+        has not yet been linked to a provider. Subsequent logins use get_by_oauth().
+        """
+        with self.engine.connect() as conn:
+            conn.execute(
+                _users.update().where(_users.c.id == user_id).values(oauth_provider=provider, oauth_subject=subject)
+            )
+            conn.commit()
+
+    def list_users(self) -> list[User]:
+        """Return all users ordered by username. Admin-only operation."""
+        with self.engine.connect() as conn:
+            rows = conn.execute(_users.select().order_by(_users.c.username)).fetchall()
+        return [_row_to_user(r) for r in rows]
+
+    def update_user(self, user_id: int, **fields) -> bool:
+        """Update mutable fields on an existing user.
+
+        Accepted fields: role, is_active, user_preferences, hashed_password.
+        is_active must be passed as bool; this method converts to int for SQLite.
+
+        Returns True if a row was updated, False if user_id was not found.
+        """
+        if "is_active" in fields:
+            fields["is_active"] = 1 if fields["is_active"] else 0
+        with self.engine.connect() as conn:
+            result = conn.execute(_users.update().where(_users.c.id == user_id).values(**fields))
+            conn.commit()
+        return result.rowcount > 0
+
+    def count_active_admins(self) -> int:
+        """Return the number of active admin users.
+
+        Used by PATCH /users/{id} to prevent deactivating the last admin [M4].
+        """
+        with self.engine.connect() as conn:
+            result = conn.execute(text("SELECT COUNT(*) FROM users WHERE role = 'admin' AND is_active = 1")).scalar()
+        return result or 0
+
+    # ------------------------------------------------------------------
+    # API key queries
+    # ------------------------------------------------------------------
+
+    def get_api_keys(self, user_id: int) -> list[ApiKey]:
+        """Return all active API keys for a user (newest first)."""
+        with self.engine.connect() as conn:
+            rows = conn.execute(
+                _api_keys.select()
+                .where((_api_keys.c.user_id == user_id) & (_api_keys.c.is_active == 1))
+                .order_by(_api_keys.c.created_at.desc())
+            ).fetchall()
+        return [_row_to_api_key(r) for r in rows]
+
+    def create_api_key(self, api_key: ApiKey) -> int:
+        """Insert a new API key record and return its ID."""
+        with self.engine.connect() as conn:
+            result = conn.execute(
+                _api_keys.insert().values(
+                    user_id=api_key.user_id,
+                    name=api_key.name,
+                    key_hash=api_key.key_hash,
+                    key_prefix=api_key.key_prefix,
+                    created_at=_now_iso(),
+                    is_active=1,
+                )
+            )
+            conn.commit()
+            return result.inserted_primary_key[0]
+
+    def get_api_key_by_hash(self, key_hash: str) -> ApiKey | None:
+        """Look up an active API key by its HMAC hash. O(1) via UNIQUE index."""
+        with self.engine.connect() as conn:
+            row = conn.execute(
+                _api_keys.select().where((_api_keys.c.key_hash == key_hash) & (_api_keys.c.is_active == 1))
+            ).fetchone()
+        return _row_to_api_key(row) if row is not None else None
+
+    def update_api_key_last_used(self, key_id: int) -> None:
+        """Stamp last_used on a key after each successful API authentication."""
+        with self.engine.connect() as conn:
+            conn.execute(_api_keys.update().where(_api_keys.c.id == key_id).values(last_used=_now_iso()))
+            conn.commit()
+
+    def revoke_api_key(self, key_id: int, user_id: int) -> bool:
+        """Deactivate a key. user_id is checked to prevent IDOR attacks.
+
+        An analyst cannot revoke another user's key even if they know the key
+        ID. Both conditions must match for the update to succeed.
+
+        Returns True if a key was revoked, False if not found or wrong owner.
+        """
+        with self.engine.connect() as conn:
+            result = conn.execute(
+                _api_keys.update()
+                .where((_api_keys.c.id == key_id) & (_api_keys.c.user_id == user_id))
+                .values(is_active=0)
+            )
+            conn.commit()
+        return result.rowcount > 0
+
+    def close(self) -> None:
+        self.engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Row mappers (Data Mapper pattern)
+# ---------------------------------------------------------------------------
+
+
+def _row_to_user(row) -> User:
+    return User(
+        id=row.id,
+        username=row.username,
+        hashed_password=row.hashed_password,
+        role=row.role,
+        oauth_provider=row.oauth_provider,
+        oauth_subject=row.oauth_subject,
+        user_preferences=row.user_preferences,
+        created_at=row.created_at,
+        is_active=bool(row.is_active),
+    )
+
+
+def _row_to_api_key(row) -> ApiKey:
+    return ApiKey(
+        id=row.id,
+        user_id=row.user_id,
+        name=row.name,
+        key_hash=row.key_hash,
+        key_prefix=row.key_prefix,
+        created_at=row.created_at,
+        last_used=row.last_used,
+        is_active=bool(row.is_active),
+    )

--- a/auth/tokens.py
+++ b/auth/tokens.py
@@ -1,0 +1,207 @@
+"""
+auth/tokens.py -- JWT, password hashing, and API key utilities.
+
+Security design decisions:
+  JWT: python-jose with HS256. Tokens are signed with SECRET_KEY and carry
+       user_id, username, role, and expiry. Verification returns None on any
+       failure -- route layer turns that into a 401.
+
+  Passwords: passlib bcrypt via CryptContext. Bcrypt is the right choice for
+       low-entropy secrets (passwords) because its cost factor makes brute-force
+       expensive. The _DUMMY_HASH constant enables timing equalization in
+       authenticate_user() so response time does not reveal whether a username
+       exists [C1].
+
+  API keys: secrets.token_hex(32) gives 256 bits of entropy -- brute-force is
+       computationally infeasible. We store HMAC-SHA256(SECRET_KEY, raw_key) so
+       lookup is O(1). bcrypt's intentional slowness is unnecessary here.
+
+  SECRET_KEY: validated at module load. A random fallback is generated if unset
+       (sessions won't survive restart) but a key shorter than 32 chars is
+       rejected outright with RuntimeError [M6].
+
+Layer rule: no imports from api/, web/, core/, cmdb/, or cache/.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+import bcrypt
+from jose import JWTError, jwt
+
+if TYPE_CHECKING:
+    from auth.models import User
+    from auth.store import UserStore
+
+logger = logging.getLogger("vulnadvisor.auth")
+
+# ---------------------------------------------------------------------------
+# Secret key -- validated at module load [M6]
+# ---------------------------------------------------------------------------
+
+_SECRET_KEY: str = os.environ.get("SECRET_KEY", "")
+if not _SECRET_KEY:
+    _SECRET_KEY = secrets.token_hex(32)
+    logger.warning(
+        "SECRET_KEY not set -- random key in use. All sessions will be invalidated on restart. "
+        "Set SECRET_KEY in your environment for persistent sessions."
+    )
+if len(_SECRET_KEY) < 32:
+    raise RuntimeError("SECRET_KEY must be at least 32 characters. " "Refusing to start with a weak signing key.")
+
+_ALGORITHM = "HS256"
+_TOKEN_EXPIRE_SECONDS = 8 * 3600  # 8 hours
+
+# ---------------------------------------------------------------------------
+# Password hashing (bcrypt -- direct usage, no passlib wrapper)
+#
+# Using bcrypt directly rather than passlib[bcrypt] because passlib's internal
+# wrap-bug detection creates a password longer than 72 bytes, which bcrypt 4.x
+# rejects with an explicit error. Direct bcrypt usage is simpler, has no
+# compatibility shim, and is actively maintained.
+# ---------------------------------------------------------------------------
+
+
+def hash_password(plain: str) -> str:
+    """Return a bcrypt hash of the given plaintext password.
+
+    Passwords longer than 72 bytes are silently truncated by bcrypt (this is
+    a known bcrypt limitation). We enforce a max_length=255 at the API layer
+    (Pydantic field), which keeps inputs well below the truncation threshold.
+    """
+    return bcrypt.hashpw(plain.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    """Return True if the plaintext password matches the bcrypt hash."""
+    try:
+        return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+    except Exception:
+        return False
+
+
+# Timing equalization dummy hash [C1].
+# Computed once at module load so the first login attempt is not measurably
+# slower than subsequent ones. Always call verify_password() even when the
+# username does not exist -- bcrypt's constant work factor equalizes timing
+# and prevents username enumeration via response-time differences.
+_DUMMY_HASH: str = hash_password("vulnadvisor_timing_dummy")
+
+
+# ---------------------------------------------------------------------------
+# JWT encode / decode
+# ---------------------------------------------------------------------------
+
+
+def create_access_token(user_id: int, username: str, role: str) -> str:
+    """Encode a signed JWT with user identity and 8-hour expiry."""
+    expire = datetime.now(timezone.utc) + timedelta(seconds=_TOKEN_EXPIRE_SECONDS)
+    payload = {
+        "sub": username,
+        "user_id": user_id,
+        "role": role,
+        "exp": expire,
+    }
+    return jwt.encode(payload, _SECRET_KEY, algorithm=_ALGORITHM)
+
+
+def decode_access_token(token: str) -> dict | None:
+    """Decode and verify a JWT. Returns the payload dict or None on any failure.
+
+    Returning None (rather than raising) keeps the caller simple: any invalid
+    token is treated as unauthenticated. Route handlers turn None into 401.
+    """
+    try:
+        payload = jwt.decode(token, _SECRET_KEY, algorithms=[_ALGORITHM])
+        if "user_id" not in payload or "role" not in payload:
+            return None
+        return payload
+    except JWTError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# User authentication (constant-time) [C1]
+# ---------------------------------------------------------------------------
+
+
+def authenticate_user(store: UserStore, username: str, password: str) -> User | None:
+    """Authenticate a local username/password login with timing equalization.
+
+    Always runs bcrypt whether or not the user exists. This prevents an attacker
+    from enumerating valid usernames by measuring response time differences:
+    - Unknown username: bcrypt runs against _DUMMY_HASH (same cost as real check)
+    - Wrong password: bcrypt runs against the real hash (same cost)
+
+    Returns the User on success, None on any failure.
+    """
+    user = store.get_by_username(username)
+    if user is None or user.hashed_password is None:
+        # Equalize timing -- do NOT return early before running bcrypt [C1]
+        verify_password(password, _DUMMY_HASH)
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    if not user.is_active:
+        return None
+    return user
+
+
+# ---------------------------------------------------------------------------
+# API key generation and hashing
+# ---------------------------------------------------------------------------
+
+
+def generate_api_key() -> str:
+    """Generate a new API key in the format: va_<64 hex chars>.
+
+    secrets.token_hex(32) produces 32 random bytes as 64 hex characters,
+    giving 256 bits of entropy. Brute-force is computationally infeasible.
+    """
+    return f"va_{secrets.token_hex(32)}"
+
+
+def hash_api_key(raw_key: str) -> str:
+    """Return HMAC-SHA256(SECRET_KEY, raw_key) as a hex string.
+
+    Using SECRET_KEY as the HMAC key means an attacker who obtains the DB
+    cannot reverse-engineer keys without also knowing SECRET_KEY. The hash
+    is deterministic, enabling O(1) lookup by hash rather than scanning all
+    active keys.
+    """
+    return hmac.new(
+        _SECRET_KEY.encode(),
+        raw_key.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Cookie helper
+# ---------------------------------------------------------------------------
+
+
+def set_auth_cookie(response, token: str) -> None:
+    """Write the JWT access token as an httpOnly cookie on the response.
+
+    httponly=True: JS cannot read the cookie (XSS mitigation).
+    samesite="lax": cookie sent on same-site navigations and GET cross-site
+        links, but not on cross-site POST -- CSRF mitigation for most cases.
+    secure: only sent over HTTPS when SECURE_COOKIES=true (set in production).
+    max_age: 8 hours, matching the JWT expiry so both expire together.
+    """
+    response.set_cookie(
+        "access_token",
+        value=token,
+        httponly=True,
+        samesite="lax",
+        secure=os.environ.get("SECURE_COOKIES", "false").lower() == "true",
+        max_age=_TOKEN_EXPIRE_SECONDS,
+    )

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,14 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
+# ---------------------------------------------------------------------------
+# Domain constants
+# ---------------------------------------------------------------------------
+
+# Canonical CVE ID format. A domain rule -- not an API contract.
+# All layers (api/, web/, CLI) that need to validate CVE IDs import from here.
+CVE_PATTERN = r"^CVE-\d{4}-\d{4,}$"
+
 
 @dataclass
 class CVSSDetails:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,11 @@ select = [
     "C4",  # flake8-comprehensions (unnecessary list/dict/set calls)
 ]
 ignore = [
-    "S101",  # assert statements — fine in non-test code here
-    "S311",  # standard pseudo-random — not used for cryptography here
+    "S101",  # assert statements -- fine in non-test code here
+    "S311",  # standard pseudo-random -- not used for cryptography here
+    "B008",  # Depends() in FastAPI defaults -- this IS the canonical FastAPI DI pattern;
+             # FastAPI inspects the signature and re-calls Depends per request, not once
+             # at definition time as the rule assumes.
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -4,3 +4,8 @@ slowapi==0.1.9
 sqlalchemy>=2.0.0,<3.0.0
 python-multipart>=0.0.9
 jinja2>=3.1.0
+python-jose[cryptography]>=3.3.0
+bcrypt>=4.0.1
+authlib>=1.3.0
+httpx>=0.27.0
+itsdangerous>=2.1.0

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -94,10 +94,30 @@
          href="/ingest">Ingest</a>
     </li>
   </ul>
-  <ul class="navbar-nav ms-auto">
+  <ul class="navbar-nav ms-auto align-items-center gap-2">
     <li class="nav-item">
       <a class="nav-link text-secondary" href="/docs" style="font-size: 0.85rem">API Docs</a>
     </li>
+    {% set current_user = try_get_current_user(request) %}
+    {% if current_user %}
+      <li class="nav-item d-flex align-items-center gap-2">
+        <span class="text-secondary" style="font-size: 0.85rem">{{ current_user.username }}</span>
+        <span class="badge
+          {% if current_user.role == 'admin' %}bg-danger
+          {% elif current_user.role == 'analyst' %}bg-primary
+          {% else %}bg-secondary{% endif %}
+          " style="font-size: 0.7rem">{{ current_user.role }}</span>
+      </li>
+      <li class="nav-item">
+        <form method="post" action="/logout" class="d-inline">
+          <button type="submit" class="btn btn-sm btn-outline-secondary" style="font-size: 0.8rem">Logout</button>
+        </form>
+      </li>
+    {% else %}
+      <li class="nav-item">
+        <a class="nav-link text-secondary" href="/login" style="font-size: 0.85rem">Login</a>
+      </li>
+    {% endif %}
   </ul>
 </nav>
 

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -1,0 +1,78 @@
+{% extends "layout.html" %}
+
+{% block title %}Login — VulnAdvisor{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center mt-5">
+  <div class="col-sm-10 col-md-7 col-lg-5 col-xl-4">
+
+    <div class="text-center mb-4">
+      <h1 class="h4 fw-bold">
+        <span style="color: #388bfd">Vuln</span><span style="color: #c9d1d9">Advisor</span>
+      </h1>
+      <p class="text-secondary" style="font-size: 0.9rem">Sign in to continue</p>
+    </div>
+
+    <div class="card">
+      <div class="card-body p-4">
+
+        {% if error_msg %}
+        <div class="alert alert-danger py-2 px-3 mb-3" style="font-size: 0.875rem">
+          {{ error_msg }}
+        </div>
+        {% endif %}
+
+        <!-- Username / Password form -->
+        <form method="post" action="/login{% if request.query_params.get('next') %}?next={{ request.query_params.get('next') }}{% endif %}">
+          <div class="mb-3">
+            <label for="username" class="form-label text-secondary" style="font-size: 0.85rem">Username</label>
+            <input
+              type="text"
+              class="form-control form-control-sm bg-dark border-secondary text-light"
+              id="username"
+              name="username"
+              autocomplete="username"
+              required
+            >
+          </div>
+          <div class="mb-3">
+            <label for="password" class="form-label text-secondary" style="font-size: 0.85rem">Password</label>
+            <input
+              type="password"
+              class="form-control form-control-sm bg-dark border-secondary text-light"
+              id="password"
+              name="password"
+              autocomplete="current-password"
+              required
+            >
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Sign in</button>
+        </form>
+
+        {% if providers %}
+        <!-- OAuth divider (only shown when at least one provider is configured) -->
+        <div class="d-flex align-items-center my-3">
+          <hr class="flex-grow-1 border-secondary">
+          <span class="px-2 text-secondary" style="font-size: 0.8rem">OR</span>
+          <hr class="flex-grow-1 border-secondary">
+        </div>
+
+        <!-- OAuth provider buttons -->
+        <div class="d-grid gap-2">
+          {% for provider in providers %}
+          <a
+            href="/login/oauth/{{ provider.name }}{% if request.query_params.get('next') %}?next={{ request.query_params.get('next') }}{% endif %}"
+            class="btn btn-outline-secondary btn-sm"
+          >
+            Continue with {{ provider.label }}
+          </a>
+          {% endfor %}
+        </div>
+        {% endif %}
+
+      </div>
+    </div>
+
+  </div>
+</div>
+{% endblock %}

--- a/web/templates/setup.html
+++ b/web/templates/setup.html
@@ -1,0 +1,84 @@
+{% extends "layout.html" %}
+
+{% block title %}First-Run Setup — VulnAdvisor{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center mt-5">
+  <div class="col-sm-10 col-md-7 col-lg-5 col-xl-4">
+
+    <div class="text-center mb-4">
+      <h1 class="h4 fw-bold">
+        <span style="color: #388bfd">Vuln</span><span style="color: #c9d1d9">Advisor</span>
+      </h1>
+      <p class="text-secondary" style="font-size: 0.9rem">Create your first admin account</p>
+    </div>
+
+    <div class="card">
+      <div class="card-header py-2 px-3">
+        <span class="fw-semibold" style="font-size: 0.9rem">Initial Setup</span>
+      </div>
+      <div class="card-body p-4">
+
+        <p class="text-secondary mb-4" style="font-size: 0.85rem">
+          No users exist yet. Create an admin account to get started. This page
+          will no longer be accessible after setup is complete.
+        </p>
+
+        {% if error_msg %}
+        <div class="alert alert-danger py-2 px-3 mb-3" style="font-size: 0.875rem">
+          {{ error_msg }}
+        </div>
+        {% endif %}
+
+        <form method="post" action="/setup">
+          <div class="mb-3">
+            <label for="username" class="form-label text-secondary" style="font-size: 0.85rem">
+              Admin username
+            </label>
+            <input
+              type="text"
+              class="form-control form-control-sm bg-dark border-secondary text-light"
+              id="username"
+              name="username"
+              autocomplete="username"
+              placeholder="e.g. admin or your email"
+              required
+            >
+          </div>
+          <div class="mb-3">
+            <label for="password" class="form-label text-secondary" style="font-size: 0.85rem">
+              Password <span class="text-muted">(min 8 characters)</span>
+            </label>
+            <input
+              type="password"
+              class="form-control form-control-sm bg-dark border-secondary text-light"
+              id="password"
+              name="password"
+              autocomplete="new-password"
+              minlength="8"
+              required
+            >
+          </div>
+          <div class="mb-4">
+            <label for="confirm_password" class="form-label text-secondary" style="font-size: 0.85rem">
+              Confirm password
+            </label>
+            <input
+              type="password"
+              class="form-control form-control-sm bg-dark border-secondary text-light"
+              id="confirm_password"
+              name="confirm_password"
+              autocomplete="new-password"
+              minlength="8"
+              required
+            >
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Create admin account</button>
+        </form>
+
+      </div>
+    </div>
+
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Adds the full auth layer for the VulnAdvisor walk phase: JWT sessions, API keys, OAuth (GitHub/Google/OIDC), and user management
- Fixes two CRITICAL layer violations found during the pre-PR tech check

## Layer violations fixed (bundled here -- found in files being modified)

- **#30** -- `CVE_PATTERN` moved from `api/models.py` to `core/models.py`. Domain constants belong in `core/`, not `api/`. `api/models.py` and `web/routes.py` now import from `core.models`.
- **#29** -- `api/main.py` no longer imports `web/`. A new top-level `asgi.py` is the sole composition root that joins `api/` and `web/` into a single ASGI app. Neither layer imports the other.

## Auth layer

- `auth/` package: `User`/`ApiKey` dataclasses, bcrypt hashing, JWT encode/decode, `UserStore` (SQLAlchemy Core), Authlib OAuth registry, FastAPI dependency helpers
- REST routes at `/api/v1/auth/*`: login, logout, me, API-keys CRUD, admin user management
- Login rate-limited to 10/min; constant-time comparison guards against username enumeration
- OAuth flow: GitHub, Google, OIDC with CSRF state via `SessionMiddleware`
- First-run setup wizard at `/setup` with race-condition guard
- `/docs` and `/redoc` protected by `get_current_user`
- `assets` and `dashboard` routers require authentication at router level

## Commit structure

1. `refactor: add asgi.py assembly layer and CVE_PATTERN domain constant` -- pure architecture fix, no auth code
2. `feat: add authentication layer` -- auth package, routes, templates, closes #29 #30 #39

## Known gaps (tracked issues)

- No auth tests yet -- `auth/` is untested; tracking in existing test scope (#21 is closed; new test issue TBD)
- `auth/oauth.py` `raise_for_status()` can propagate to ASGI layer -- tracked in #31
- Login rate-limit magic number should be extracted -- tracked in #35

## Test plan

- [ ] `make run-api` starts without errors (`uvicorn asgi:app`)
- [ ] `GET /api/v1/health` returns 200
- [ ] `GET /setup` renders first-run wizard
- [ ] `POST /setup` creates admin account and redirects to `/`
- [ ] `POST /api/v1/auth/login` with valid credentials returns JWT + sets cookie
- [ ] `GET /api/v1/auth/me` with cookie returns current user
- [ ] `GET /assets` without cookie redirects to `/login`
- [ ] `GET /docs` without auth redirects to login
- [ ] `python -m pytest tests/` passes (enricher tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)