### PR TITLE
feat: wire NVD API key support via NVD_API_KEY env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-# VulnAdvisor — Environment Variables
+# VulnAdvisor -- Environment Variables
 # Copy this file to .env and fill in values as needed.
-# The core tool requires NO API keys — all data sources are free.
-#
+# The core tool requires NO API keys -- all data sources are free.
+
+# NVD API key -- optional but recommended for higher rate limits (50 req/30s vs 5 req/30s)
+# Get yours at: https://nvd.nist.gov/developers/request-an-api-key
+NVD_API_KEY=
+
 # Reserved for future paid/AI-enhanced features:
 # ANTHROPIC_API_KEY=your-key-here

--- a/core/fetcher.py
+++ b/core/fetcher.py
@@ -1,9 +1,10 @@
 """
-fetcher.py — All external data fetching.
-All sources are free and require no API keys.
+fetcher.py -- All external data fetching.
+All sources are free. NVD optionally accepts an API key for higher rate limits.
 """
 
 import logging
+import os
 import threading
 from typing import Any, Optional
 
@@ -16,8 +17,13 @@ CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_v
 EPSS_API = "https://api.first.org/data/v1/epss"
 POC_GITHUB = "https://raw.githubusercontent.com/nomi-sec/PoC-in-GitHub/master/{year}/{cve_id}.json"
 
+# NVD_API_KEY is optional. When set, NVD allows 50 req/30s instead of 5 req/30s.
+# Read once at module load so the value is consistent for the process lifetime.
+# Get a free key at: https://nvd.nist.gov/developers/request-an-api-key
+_NVD_API_KEY: Optional[str] = os.environ.get("NVD_API_KEY") or None
+
 # Module-level session shared across all fetcher calls for connection pooling.
-# max_redirects=3 replaces the requests default of 30 — these are known public APIs,
+# max_redirects=3 replaces the requests default of 30 -- these are known public APIs,
 # 3 hops is generous and protects against open redirect / SSRF via redirect chains.
 _session = requests.Session()
 _session.max_redirects = 3
@@ -31,13 +37,21 @@ def fetch_nvd(cve_id: str, api_key: Optional[str] = None) -> Optional[dict[str, 
 
     Args:
         cve_id:  CVE identifier, e.g. "CVE-2021-44228".
-        api_key: Optional NVD API key (header: apiKey). Raises rate limit from
-                 5 req/min (unauthenticated) to 50 req/min (authenticated).
+        api_key: Optional NVD API key override. When not provided, the module
+                 reads NVD_API_KEY from the environment automatically. Passing
+                 a key raises the NVD rate limit from 5 req/30s (unauthenticated)
+                 to 50 req/30s (authenticated).
                  Free registration at https://nvd.nist.gov/developers/request-an-api-key
+
+    Gracefully falls back to unauthenticated calls if no key is available.
     """
+    # Explicit caller argument takes precedence; fall back to the module-level env var.
+    effective_key = api_key or _NVD_API_KEY
     try:
-        headers = {"apiKey": api_key} if api_key else {}
-        resp = _session.get(NVD_API, params={"cveId": cve_id}, headers=headers, timeout=10)
+        params: dict[str, str] = {"cveId": cve_id}
+        if effective_key:
+            params["apiKey"] = effective_key
+        resp = _session.get(NVD_API, params=params, timeout=10)
         resp.raise_for_status()
         vulns = resp.json().get("vulnerabilities", [])
         return vulns[0].get("cve") if vulns else None


### PR DESCRIPTION
## Summary

- Reads \`NVD_API_KEY\` from environment at module load in \`core/fetcher.py\`; passes it as the \`apiKey\` query parameter in \`fetch_nvd()\` (NVD v2 uses a query param, not a header)
- Explicit \`api_key\` argument on \`fetch_nvd()\` still overrides the env var, so callers and tests can inject a key without touching the environment
- Empty string (default in \`.env.example\`) is coerced to \`None\` -- an unset key is never sent to NVD
- Falls back to unauthenticated rate limit (5 req/30s) when no key is set -- no behavior change for existing callers
- Documents \`NVD_API_KEY\` in \`.env.example\` with rate limit context and NVD registration link

## Test plan

- [ ] With \`NVD_API_KEY\` unset: \`python main.py CVE-2021-44228\` works as before
- [ ] With \`NVD_API_KEY=<key>\` exported: \`apiKey\` appears as a query parameter in NVD requests
- [ ] \`make check\` passes
- [ ] Existing tests pass (\`tests/test_pipeline.py\` mocks \`fetch_nvd\` so env var has no effect in test context)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)